### PR TITLE
feat : use IdGeneratorType to remove deprecated GenericGenerator

### DIFF
--- a/jpa/boot-data-customsequence/src/main/java/com/example/custom/sequence/config/StringPrefixedNumberFormattedSequenceIdGenerator.java
+++ b/jpa/boot-data-customsequence/src/main/java/com/example/custom/sequence/config/StringPrefixedNumberFormattedSequenceIdGenerator.java
@@ -1,25 +1,33 @@
 package com.example.custom.sequence.config;
 
 import java.io.Serializable;
+import java.lang.reflect.Member;
 import java.util.Properties;
 import org.hibernate.HibernateException;
 import org.hibernate.MappingException;
 import org.hibernate.engine.spi.SharedSessionContractImplementor;
 import org.hibernate.id.enhanced.SequenceStyleGenerator;
-import org.hibernate.internal.util.config.ConfigurationHelper;
+import org.hibernate.id.factory.spi.CustomIdGeneratorCreationContext;
 import org.hibernate.service.ServiceRegistry;
 import org.hibernate.type.Type;
 import org.hibernate.type.spi.TypeConfiguration;
 
 public class StringPrefixedNumberFormattedSequenceIdGenerator extends SequenceStyleGenerator {
 
-    public static final String VALUE_PREFIX_PARAMETER = "valuePrefix";
-    public static final String VALUE_PREFIX_DEFAULT = "";
     private String valuePrefix;
-
-    public static final String NUMBER_FORMAT_PARAMETER = "numberFormat";
-    public static final String NUMBER_FORMAT_DEFAULT = "%d";
     private String numberFormat;
+
+    StringPrefixedNumberFormattedSequenceIdGenerator() {
+        super();
+    }
+
+    public StringPrefixedNumberFormattedSequenceIdGenerator(
+            StringPrefixedSequence config,
+            Member annotatedMember,
+            CustomIdGeneratorCreationContext context) {
+        valuePrefix = config.valuePrefix();
+        numberFormat = config.numberFormat();
+    }
 
     @Override
     public Serializable generate(SharedSessionContractImplementor session, Object object)
@@ -34,10 +42,5 @@ public class StringPrefixedNumberFormattedSequenceIdGenerator extends SequenceSt
                 new TypeConfiguration().getBasicTypeRegistry().getRegisteredType(Long.class),
                 params,
                 serviceRegistry);
-        valuePrefix =
-                ConfigurationHelper.getString(VALUE_PREFIX_PARAMETER, params, VALUE_PREFIX_DEFAULT);
-        numberFormat =
-                ConfigurationHelper.getString(
-                        NUMBER_FORMAT_PARAMETER, params, NUMBER_FORMAT_DEFAULT);
     }
 }

--- a/jpa/boot-data-customsequence/src/main/java/com/example/custom/sequence/config/StringPrefixedSequence.java
+++ b/jpa/boot-data-customsequence/src/main/java/com/example/custom/sequence/config/StringPrefixedSequence.java
@@ -1,0 +1,19 @@
+package com.example.custom.sequence.config;
+
+import static java.lang.annotation.ElementType.FIELD;
+import static java.lang.annotation.ElementType.METHOD;
+import static java.lang.annotation.RetentionPolicy.RUNTIME;
+
+import java.lang.annotation.Retention;
+import java.lang.annotation.Target;
+import org.hibernate.annotations.IdGeneratorType;
+
+@IdGeneratorType(StringPrefixedNumberFormattedSequenceIdGenerator.class)
+@Retention(RUNTIME)
+@Target({METHOD, FIELD})
+public @interface StringPrefixedSequence {
+
+    String valuePrefix() default "";
+
+    String numberFormat() default "%d";
+}

--- a/jpa/boot-data-customsequence/src/main/java/com/example/custom/sequence/entities/Customer.java
+++ b/jpa/boot-data-customsequence/src/main/java/com/example/custom/sequence/entities/Customer.java
@@ -1,6 +1,6 @@
 package com.example.custom.sequence.entities;
 
-import com.example.custom.sequence.config.StringPrefixedNumberFormattedSequenceIdGenerator;
+import com.example.custom.sequence.config.StringPrefixedSequence;
 import jakarta.persistence.CascadeType;
 import jakarta.persistence.Column;
 import jakarta.persistence.Entity;
@@ -18,8 +18,6 @@ import lombok.Getter;
 import lombok.NoArgsConstructor;
 import lombok.Setter;
 import org.hibernate.Hibernate;
-import org.hibernate.annotations.GenericGenerator;
-import org.hibernate.annotations.Parameter;
 
 @Entity
 @Table(name = "customers")
@@ -31,21 +29,7 @@ public class Customer {
 
     @Id
     @GeneratedValue(strategy = GenerationType.SEQUENCE, generator = "custom_seq")
-    @GenericGenerator(
-            name = "custom_seq",
-            type = StringPrefixedNumberFormattedSequenceIdGenerator.class,
-            parameters = {
-                @Parameter(
-                        name =
-                                StringPrefixedNumberFormattedSequenceIdGenerator
-                                        .VALUE_PREFIX_PARAMETER,
-                        value = "CUS_"),
-                @Parameter(
-                        name =
-                                StringPrefixedNumberFormattedSequenceIdGenerator
-                                        .NUMBER_FORMAT_PARAMETER,
-                        value = "%05d")
-            })
+    @StringPrefixedSequence(valuePrefix = "CUS_", numberFormat = "%05d")
     private String id;
 
     @Column(nullable = false)

--- a/jpa/boot-data-customsequence/src/main/java/com/example/custom/sequence/entities/Order.java
+++ b/jpa/boot-data-customsequence/src/main/java/com/example/custom/sequence/entities/Order.java
@@ -1,6 +1,6 @@
 package com.example.custom.sequence.entities;
 
-import com.example.custom.sequence.config.StringPrefixedNumberFormattedSequenceIdGenerator;
+import com.example.custom.sequence.config.StringPrefixedSequence;
 import jakarta.persistence.Column;
 import jakarta.persistence.Entity;
 import jakarta.persistence.FetchType;
@@ -17,7 +17,6 @@ import lombok.Getter;
 import lombok.NoArgsConstructor;
 import lombok.Setter;
 import org.hibernate.Hibernate;
-import org.hibernate.annotations.GenericGenerator;
 
 @Entity
 @Table(name = "orders")
@@ -29,9 +28,7 @@ public class Order {
 
     @Id
     @GeneratedValue(strategy = GenerationType.SEQUENCE, generator = "custom_seq")
-    @GenericGenerator(
-            name = "custom_seq",
-            type = StringPrefixedNumberFormattedSequenceIdGenerator.class)
+    @StringPrefixedSequence(numberFormat = "%09d")
     private String id;
 
     @Column(nullable = false)

--- a/jpa/boot-data-customsequence/src/main/resources/db/changelog/migration/01-init.xml
+++ b/jpa/boot-data-customsequence/src/main/resources/db/changelog/migration/01-init.xml
@@ -3,6 +3,6 @@
         xmlns="http://www.liquibase.org/xml/ns/dbchangelog"
         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
         xsi:schemaLocation="http://www.liquibase.org/xml/ns/dbchangelog
-         http://www.liquibase.org/xml/ns/dbchangelog/dbchangelog-3.2.xsd">
+         http://www.liquibase.org/xml/ns/dbchangelog/dbchangelog-4.20.xsd">
 
 </databaseChangeLog>

--- a/jpa/boot-data-customsequence/src/main/resources/db/changelog/migration/02-create_customers_table.xml
+++ b/jpa/boot-data-customsequence/src/main/resources/db/changelog/migration/02-create_customers_table.xml
@@ -2,11 +2,11 @@
 <databaseChangeLog
     xmlns="http://www.liquibase.org/xml/ns/dbchangelog"
     xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-    xsi:schemaLocation="http://www.liquibase.org/xml/ns/dbchangelog http://www.liquibase.org/xml/ns/dbchangelog/dbchangelog-3.2.xsd">
+    xsi:schemaLocation="http://www.liquibase.org/xml/ns/dbchangelog http://www.liquibase.org/xml/ns/dbchangelog/dbchangelog-4.20.xsd">
     <changeSet author="app" id="createTable-customers">
 
         <createSequence
-            sequenceName="custom_seq"
+            sequenceName="customers_seq"
             incrementBy="50" />
 
         <createTable tableName="customers">


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Introduced a new custom annotation `@StringPrefixedSequence` for generating sequence IDs with string prefixes and specific number formats.

- **Improvements**
  - Updated `Customer` and `Order` entities to use the new `@StringPrefixedSequence` for sequence ID generation.
  - Enhanced Liquibase database changelog XML files to the latest schema version 4.20 for improved compatibility.

- **Refactor**
  - Replaced the `StringPrefixedNumberFormattedSequenceIdGenerator` with a new generator leveraging `@StringPrefixedSequence`.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->