### PR TITLE
feat : use `@MockitoBean` instead of `@MockBean` for service mocking

### DIFF
--- a/boot-chaos-monkey/src/test/java/com/example/choasmonkey/web/controllers/CustomerControllerTest.java
+++ b/boot-chaos-monkey/src/test/java/com/example/choasmonkey/web/controllers/CustomerControllerTest.java
@@ -27,9 +27,9 @@ import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
-import org.springframework.boot.test.mock.mockito.MockBean;
 import org.springframework.http.MediaType;
 import org.springframework.test.context.ActiveProfiles;
+import org.springframework.test.context.bean.override.mockito.MockitoBean;
 import org.springframework.test.web.servlet.MockMvc;
 
 @WebMvcTest(controllers = CustomerController.class)
@@ -38,8 +38,8 @@ class CustomerControllerTest {
 
     @Autowired private MockMvc mockMvc;
 
-    @MockBean private CustomerService customerService;
-    @MockBean private ObservationRegistry observationRegistry;
+    @MockitoBean private CustomerService customerService;
+    @MockitoBean private ObservationRegistry observationRegistry;
 
     @Autowired private ObjectMapper objectMapper;
 

--- a/boot-opensearch-sample/src/test/java/com/example/opensearch/web/controllers/RestaurantControllerTest.java
+++ b/boot-opensearch-sample/src/test/java/com/example/opensearch/web/controllers/RestaurantControllerTest.java
@@ -29,12 +29,12 @@ import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
-import org.springframework.boot.test.mock.mockito.MockBean;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.PageImpl;
 import org.springframework.data.geo.Point;
 import org.springframework.http.MediaType;
 import org.springframework.test.context.ActiveProfiles;
+import org.springframework.test.context.bean.override.mockito.MockitoBean;
 import org.springframework.test.web.servlet.MockMvc;
 
 @WebMvcTest(controllers = RestaurantController.class)
@@ -43,7 +43,7 @@ class RestaurantControllerTest {
 
     @Autowired private MockMvc mockMvc;
 
-    @MockBean private RestaurantService restaurantService;
+    @MockitoBean private RestaurantService restaurantService;
 
     @Autowired private ObjectMapper objectMapper;
 

--- a/boot-rest-docs-sample/src/test/java/com/example/restdocs/web/controllers/UserControllerTest.java
+++ b/boot-rest-docs-sample/src/test/java/com/example/restdocs/web/controllers/UserControllerTest.java
@@ -38,12 +38,12 @@ import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.autoconfigure.restdocs.AutoConfigureRestDocs;
 import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
-import org.springframework.boot.test.mock.mockito.MockBean;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.PageImpl;
 import org.springframework.http.MediaType;
 import org.springframework.restdocs.payload.FieldDescriptor;
 import org.springframework.test.context.ActiveProfiles;
+import org.springframework.test.context.bean.override.mockito.MockitoBean;
 import org.springframework.test.web.servlet.MockMvc;
 
 @WebMvcTest(controllers = UserController.class)
@@ -53,7 +53,7 @@ class UserControllerTest {
 
     @Autowired private MockMvc mockMvc;
 
-    @MockBean private UserService userService;
+    @MockitoBean private UserService userService;
 
     @Autowired private ObjectMapper objectMapper;
 

--- a/graphql/boot-graphql-querydsl/src/test/java/com/example/graphql/querydsl/web/controllers/PostCommentControllerTest.java
+++ b/graphql/boot-graphql-querydsl/src/test/java/com/example/graphql/querydsl/web/controllers/PostCommentControllerTest.java
@@ -33,12 +33,12 @@ import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
-import org.springframework.boot.test.mock.mockito.MockBean;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.PageImpl;
 import org.springframework.http.HttpHeaders;
 import org.springframework.http.MediaType;
 import org.springframework.test.context.ActiveProfiles;
+import org.springframework.test.context.bean.override.mockito.MockitoBean;
 import org.springframework.test.web.servlet.MockMvc;
 
 @WebMvcTest(controllers = PostCommentController.class)
@@ -48,7 +48,7 @@ class PostCommentControllerTest {
     @Autowired
     private MockMvc mockMvc;
 
-    @MockBean
+    @MockitoBean
     private PostCommentService postCommentService;
 
     @Autowired

--- a/graphql/boot-graphql-querydsl/src/test/java/com/example/graphql/querydsl/web/controllers/PostControllerTest.java
+++ b/graphql/boot-graphql-querydsl/src/test/java/com/example/graphql/querydsl/web/controllers/PostControllerTest.java
@@ -37,12 +37,12 @@ import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
-import org.springframework.boot.test.mock.mockito.MockBean;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.PageImpl;
 import org.springframework.http.HttpHeaders;
 import org.springframework.http.MediaType;
 import org.springframework.test.context.ActiveProfiles;
+import org.springframework.test.context.bean.override.mockito.MockitoBean;
 import org.springframework.test.web.servlet.MockMvc;
 
 @WebMvcTest(controllers = PostController.class)
@@ -52,7 +52,7 @@ class PostControllerTest {
     @Autowired
     private MockMvc mockMvc;
 
-    @MockBean
+    @MockitoBean
     private PostService postService;
 
     @Autowired

--- a/graphql/boot-graphql-querydsl/src/test/java/com/example/graphql/querydsl/web/controllers/TagControllerTest.java
+++ b/graphql/boot-graphql-querydsl/src/test/java/com/example/graphql/querydsl/web/controllers/TagControllerTest.java
@@ -31,12 +31,12 @@ import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
-import org.springframework.boot.test.mock.mockito.MockBean;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.PageImpl;
 import org.springframework.http.HttpHeaders;
 import org.springframework.http.MediaType;
 import org.springframework.test.context.ActiveProfiles;
+import org.springframework.test.context.bean.override.mockito.MockitoBean;
 import org.springframework.test.web.servlet.MockMvc;
 
 @WebMvcTest(controllers = TagController.class)
@@ -46,7 +46,7 @@ class TagControllerTest {
     @Autowired
     private MockMvc mockMvc;
 
-    @MockBean
+    @MockitoBean
     private TagService tagService;
 
     @Autowired

--- a/graphql/boot-graphql-webflux/src/test/java/com/example/graphql/controller/CustomerGraphQLControllerTest.java
+++ b/graphql/boot-graphql-webflux/src/test/java/com/example/graphql/controller/CustomerGraphQLControllerTest.java
@@ -11,8 +11,8 @@ import java.util.Map;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.autoconfigure.graphql.GraphQlTest;
-import org.springframework.boot.test.mock.mockito.MockBean;
 import org.springframework.graphql.test.tester.GraphQlTester;
+import org.springframework.test.context.bean.override.mockito.MockitoBean;
 import reactor.core.publisher.Flux;
 import reactor.core.publisher.Mono;
 
@@ -22,7 +22,7 @@ class CustomerGraphQLControllerTest {
     @Autowired
     private GraphQlTester graphQlTester;
 
-    @MockBean
+    @MockitoBean
     private CustomerGraphQLService customerGraphQLService;
 
     @Test

--- a/graphql/boot-graphql-webmvc/src/test/java/com/example/graphql/gql/AuthorEntityQueryTest.java
+++ b/graphql/boot-graphql-webmvc/src/test/java/com/example/graphql/gql/AuthorEntityQueryTest.java
@@ -19,9 +19,9 @@ import java.util.Optional;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.autoconfigure.graphql.GraphQlTest;
-import org.springframework.boot.test.mock.mockito.MockBean;
 import org.springframework.context.annotation.Import;
 import org.springframework.graphql.test.tester.GraphQlTester;
+import org.springframework.test.context.bean.override.mockito.MockitoBean;
 
 @GraphQlTest(AuthorGraphQlController.class)
 @Import(GraphQlConfiguration.class)
@@ -30,16 +30,16 @@ class AuthorEntityQueryTest {
     @Autowired
     private GraphQlTester graphQlTester;
 
-    @MockBean
+    @MockitoBean
     AuthorService authorService;
 
-    @MockBean
+    @MockitoBean
     PostService postService;
 
-    @MockBean
+    @MockitoBean
     PostCommentService postCommentService;
 
-    @MockBean
+    @MockitoBean
     TagService tagService;
 
     @Test

--- a/graphql/boot-graphql-webmvc/src/test/java/com/example/graphql/web/controllers/AuthorEntityControllerTest.java
+++ b/graphql/boot-graphql-webmvc/src/test/java/com/example/graphql/web/controllers/AuthorEntityControllerTest.java
@@ -27,10 +27,10 @@ import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
-import org.springframework.boot.test.mock.mockito.MockBean;
 import org.springframework.http.HttpHeaders;
 import org.springframework.http.MediaType;
 import org.springframework.test.context.ActiveProfiles;
+import org.springframework.test.context.bean.override.mockito.MockitoBean;
 import org.springframework.test.web.servlet.MockMvc;
 
 @WebMvcTest(controllers = AuthorController.class)
@@ -40,7 +40,7 @@ class AuthorEntityControllerTest {
     @Autowired
     private MockMvc mockMvc;
 
-    @MockBean
+    @MockitoBean
     private AuthorService authorService;
 
     @Autowired

--- a/graphql/boot-graphql-webmvc/src/test/java/com/example/graphql/web/controllers/PostCommentEntityControllerTest.java
+++ b/graphql/boot-graphql-webmvc/src/test/java/com/example/graphql/web/controllers/PostCommentEntityControllerTest.java
@@ -28,9 +28,9 @@ import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
-import org.springframework.boot.test.mock.mockito.MockBean;
 import org.springframework.http.MediaType;
 import org.springframework.test.context.ActiveProfiles;
+import org.springframework.test.context.bean.override.mockito.MockitoBean;
 import org.springframework.test.web.servlet.MockMvc;
 
 @WebMvcTest(controllers = PostCommentController.class)
@@ -40,7 +40,7 @@ class PostCommentEntityControllerTest {
     @Autowired
     private MockMvc mockMvc;
 
-    @MockBean
+    @MockitoBean
     private PostCommentService postCommentService;
 
     @Autowired

--- a/graphql/boot-graphql-webmvc/src/test/java/com/example/graphql/web/controllers/PostDetailsEntityControllerTest.java
+++ b/graphql/boot-graphql-webmvc/src/test/java/com/example/graphql/web/controllers/PostDetailsEntityControllerTest.java
@@ -21,9 +21,9 @@ import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
-import org.springframework.boot.test.mock.mockito.MockBean;
 import org.springframework.http.MediaType;
 import org.springframework.test.context.ActiveProfiles;
+import org.springframework.test.context.bean.override.mockito.MockitoBean;
 import org.springframework.test.web.servlet.MockMvc;
 
 @WebMvcTest(controllers = PostDetailsController.class)
@@ -33,7 +33,7 @@ class PostDetailsEntityControllerTest {
     @Autowired
     private MockMvc mockMvc;
 
-    @MockBean
+    @MockitoBean
     private PostDetailsService postDetailsService;
 
     @Autowired

--- a/graphql/boot-graphql-webmvc/src/test/java/com/example/graphql/web/controllers/PostEntityControllerTest.java
+++ b/graphql/boot-graphql-webmvc/src/test/java/com/example/graphql/web/controllers/PostEntityControllerTest.java
@@ -27,10 +27,10 @@ import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
-import org.springframework.boot.test.mock.mockito.MockBean;
 import org.springframework.http.HttpHeaders;
 import org.springframework.http.MediaType;
 import org.springframework.test.context.ActiveProfiles;
+import org.springframework.test.context.bean.override.mockito.MockitoBean;
 import org.springframework.test.web.servlet.MockMvc;
 
 @WebMvcTest(controllers = PostController.class)
@@ -40,7 +40,7 @@ class PostEntityControllerTest {
     @Autowired
     private MockMvc mockMvc;
 
-    @MockBean
+    @MockitoBean
     private PostService postService;
 
     @Autowired

--- a/graphql/boot-graphql-webmvc/src/test/java/com/example/graphql/web/controllers/TagEntityControllerTest.java
+++ b/graphql/boot-graphql-webmvc/src/test/java/com/example/graphql/web/controllers/TagEntityControllerTest.java
@@ -26,10 +26,10 @@ import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
-import org.springframework.boot.test.mock.mockito.MockBean;
 import org.springframework.http.HttpHeaders;
 import org.springframework.http.MediaType;
 import org.springframework.test.context.ActiveProfiles;
+import org.springframework.test.context.bean.override.mockito.MockitoBean;
 import org.springframework.test.web.servlet.MockMvc;
 
 @WebMvcTest(controllers = TagController.class)
@@ -39,7 +39,7 @@ class TagEntityControllerTest {
     @Autowired
     private MockMvc mockMvc;
 
-    @MockBean
+    @MockitoBean
     private TagService tagService;
 
     @Autowired

--- a/httpClients/boot-http-proxy/src/test/java/com/example/rest/proxy/web/controllers/PostControllerTest.java
+++ b/httpClients/boot-http-proxy/src/test/java/com/example/rest/proxy/web/controllers/PostControllerTest.java
@@ -24,9 +24,9 @@ import java.util.Optional;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
-import org.springframework.boot.test.mock.mockito.MockBean;
 import org.springframework.http.MediaType;
 import org.springframework.test.context.ActiveProfiles;
+import org.springframework.test.context.bean.override.mockito.MockitoBean;
 import org.springframework.test.web.servlet.MockMvc;
 
 @WebMvcTest(controllers = PostController.class)
@@ -35,7 +35,7 @@ class PostControllerTest {
 
     @Autowired private MockMvc mockMvc;
 
-    @MockBean private PostService postService;
+    @MockitoBean private PostService postService;
 
     @Autowired private ObjectMapper objectMapper;
 

--- a/httpClients/boot-rest-template/src/test/java/com/example/rest/template/web/controllers/PostControllerTest.java
+++ b/httpClients/boot-rest-template/src/test/java/com/example/rest/template/web/controllers/PostControllerTest.java
@@ -26,11 +26,11 @@ import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
-import org.springframework.boot.test.mock.mockito.MockBean;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.PageImpl;
 import org.springframework.http.MediaType;
 import org.springframework.test.context.ActiveProfiles;
+import org.springframework.test.context.bean.override.mockito.MockitoBean;
 import org.springframework.test.web.servlet.MockMvc;
 
 @WebMvcTest(controllers = PostController.class)
@@ -39,7 +39,7 @@ class PostControllerTest {
 
     @Autowired private MockMvc mockMvc;
 
-    @MockBean private PostService postService;
+    @MockitoBean private PostService postService;
 
     @Autowired private ObjectMapper objectMapper;
 

--- a/httpClients/boot-restclient/src/test/java/com/example/restclient/bootrestclient/web/controllers/PostControllerTest.java
+++ b/httpClients/boot-restclient/src/test/java/com/example/restclient/bootrestclient/web/controllers/PostControllerTest.java
@@ -24,9 +24,9 @@ import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
-import org.springframework.boot.test.mock.mockito.MockBean;
 import org.springframework.http.MediaType;
 import org.springframework.test.context.ActiveProfiles;
+import org.springframework.test.context.bean.override.mockito.MockitoBean;
 import org.springframework.test.web.servlet.MockMvc;
 
 @WebMvcTest(controllers = PostController.class)
@@ -35,7 +35,7 @@ class PostControllerTest {
 
     @Autowired private MockMvc mockMvc;
 
-    @MockBean private PostService postService;
+    @MockitoBean private PostService postService;
 
     @Autowired private ObjectMapper objectMapper;
 

--- a/httpClients/boot-web-client-mvc/src/test/java/com/example/rest/webclient/web/controllers/PostControllerTest.java
+++ b/httpClients/boot-web-client-mvc/src/test/java/com/example/rest/webclient/web/controllers/PostControllerTest.java
@@ -24,9 +24,9 @@ import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
-import org.springframework.boot.test.mock.mockito.MockBean;
 import org.springframework.http.MediaType;
 import org.springframework.test.context.ActiveProfiles;
+import org.springframework.test.context.bean.override.mockito.MockitoBean;
 import org.springframework.test.web.servlet.MockMvc;
 
 @WebMvcTest(controllers = PostController.class)
@@ -35,7 +35,7 @@ class PostControllerTest {
 
     @Autowired private MockMvc mockMvc;
 
-    @MockBean private PostService postService;
+    @MockitoBean private PostService postService;
 
     @Autowired private ObjectMapper objectMapper;
 

--- a/httpClients/boot-web-client-webflux/src/test/java/com/example/rest/webclient/web/controllers/PostControllerTest.java
+++ b/httpClients/boot-web-client-webflux/src/test/java/com/example/rest/webclient/web/controllers/PostControllerTest.java
@@ -16,10 +16,10 @@ import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.autoconfigure.web.reactive.WebFluxTest;
-import org.springframework.boot.test.mock.mockito.MockBean;
 import org.springframework.http.MediaType;
 import org.springframework.http.ProblemDetail;
 import org.springframework.test.context.ActiveProfiles;
+import org.springframework.test.context.bean.override.mockito.MockitoBean;
 import org.springframework.test.web.reactive.server.WebTestClient;
 import org.springframework.web.reactive.function.BodyInserters;
 import reactor.core.publisher.Flux;
@@ -31,7 +31,7 @@ class PostControllerTest {
 
     @Autowired private WebTestClient webTestClient;
 
-    @MockBean private PostService postService;
+    @MockitoBean private PostService postService;
 
     @Autowired private ObjectMapper objectMapper;
 

--- a/jpa/boot-jndi-sample/src/test/java/com/example/jndi/web/controllers/DriverControllerTest.java
+++ b/jpa/boot-jndi-sample/src/test/java/com/example/jndi/web/controllers/DriverControllerTest.java
@@ -31,12 +31,12 @@ import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
-import org.springframework.boot.test.mock.mockito.MockBean;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.PageImpl;
 import org.springframework.http.HttpHeaders;
 import org.springframework.http.MediaType;
 import org.springframework.test.context.ActiveProfiles;
+import org.springframework.test.context.bean.override.mockito.MockitoBean;
 import org.springframework.test.web.servlet.MockMvc;
 
 @WebMvcTest(controllers = DriverController.class)
@@ -46,7 +46,7 @@ class DriverControllerTest {
     @Autowired
     private MockMvc mockMvc;
 
-    @MockBean
+    @MockitoBean
     private DriverService driverService;
 
     @Autowired

--- a/jpa/multitenancy/partition/src/test/java/com/example/multitenancy/partition/web/controllers/CustomerControllerTest.java
+++ b/jpa/multitenancy/partition/src/test/java/com/example/multitenancy/partition/web/controllers/CustomerControllerTest.java
@@ -23,9 +23,9 @@ import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
-import org.springframework.boot.test.mock.mockito.MockBean;
 import org.springframework.http.MediaType;
 import org.springframework.test.context.ActiveProfiles;
+import org.springframework.test.context.bean.override.mockito.MockitoBean;
 import org.springframework.test.web.servlet.MockMvc;
 
 @WebMvcTest(controllers = CustomerController.class)
@@ -34,9 +34,9 @@ class CustomerControllerTest {
 
     @Autowired private MockMvc mockMvc;
 
-    @MockBean private CustomerService customerService;
+    @MockitoBean private CustomerService customerService;
 
-    @MockBean private TenantIdentifierResolver tenantIdentifierResolver;
+    @MockitoBean private TenantIdentifierResolver tenantIdentifierResolver;
 
     @Autowired private ObjectMapper objectMapper;
 

--- a/jpa/multitenancy/schema/src/test/java/com/example/multitenancy/schema/web/controllers/CustomerControllerTest.java
+++ b/jpa/multitenancy/schema/src/test/java/com/example/multitenancy/schema/web/controllers/CustomerControllerTest.java
@@ -27,10 +27,10 @@ import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
-import org.springframework.boot.test.mock.mockito.MockBean;
 import org.springframework.http.HttpHeaders;
 import org.springframework.http.MediaType;
 import org.springframework.test.context.ActiveProfiles;
+import org.springframework.test.context.bean.override.mockito.MockitoBean;
 import org.springframework.test.web.servlet.MockMvc;
 
 @WebMvcTest(controllers = CustomerController.class)
@@ -40,8 +40,8 @@ class CustomerControllerTest {
     @Autowired private MockMvc mockMvc;
     @Autowired private ObjectMapper objectMapper;
 
-    @MockBean private CustomerService customerService;
-    @MockBean private TenantIdentifierResolver tenantIdentifierResolver;
+    @MockitoBean private CustomerService customerService;
+    @MockitoBean private TenantIdentifierResolver tenantIdentifierResolver;
 
     private List<Customer> customerList;
     private final String tenant = "test1";

--- a/r2dbc/boot-r2dbc-sample/src/test/java/com/example/bootr2dbc/web/controllers/ReactiveCommentsControllerTest.java
+++ b/r2dbc/boot-r2dbc-sample/src/test/java/com/example/bootr2dbc/web/controllers/ReactiveCommentsControllerTest.java
@@ -16,11 +16,11 @@ import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.autoconfigure.web.reactive.WebFluxTest;
-import org.springframework.boot.test.mock.mockito.MockBean;
 import org.springframework.context.annotation.Import;
 import org.springframework.http.MediaType;
 import org.springframework.security.test.context.support.WithMockUser;
 import org.springframework.test.context.ActiveProfiles;
+import org.springframework.test.context.bean.override.mockito.MockitoBean;
 import org.springframework.test.web.reactive.server.WebTestClient;
 import org.springframework.web.reactive.function.BodyInserters;
 import reactor.core.publisher.Flux;
@@ -34,7 +34,7 @@ class ReactiveCommentsControllerTest {
 
     @Autowired private WebTestClient webTestClient;
 
-    @MockBean private ReactiveCommentsService reactiveCommentsService;
+    @MockitoBean private ReactiveCommentsService reactiveCommentsService;
 
     private Flux<ReactiveComments> reactiveCommentsFlux;
 

--- a/r2dbc/boot-r2dbc-sample/src/test/java/com/example/bootr2dbc/web/controllers/ReactivePostControllerTest.java
+++ b/r2dbc/boot-r2dbc-sample/src/test/java/com/example/bootr2dbc/web/controllers/ReactivePostControllerTest.java
@@ -16,12 +16,12 @@ import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.autoconfigure.web.reactive.WebFluxTest;
-import org.springframework.boot.test.mock.mockito.MockBean;
 import org.springframework.context.annotation.Import;
 import org.springframework.http.MediaType;
 import org.springframework.http.ResponseEntity;
 import org.springframework.security.test.context.support.WithMockUser;
 import org.springframework.test.context.ActiveProfiles;
+import org.springframework.test.context.bean.override.mockito.MockitoBean;
 import org.springframework.test.web.reactive.server.WebTestClient;
 import org.springframework.web.reactive.function.BodyInserters;
 import reactor.core.publisher.Flux;
@@ -35,7 +35,7 @@ class ReactivePostControllerTest {
 
     @Autowired private WebTestClient webTestClient;
 
-    @MockBean private ReactivePostService reactivePostService;
+    @MockitoBean private ReactivePostService reactivePostService;
 
     private Flux<ReactivePost> reactivePostFlux;
 

--- a/scheduler/boot-scheduler-shedlock/src/test/java/com/learning/shedlock/web/controllers/JobControllerTest.java
+++ b/scheduler/boot-scheduler-shedlock/src/test/java/com/learning/shedlock/web/controllers/JobControllerTest.java
@@ -31,12 +31,12 @@ import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
-import org.springframework.boot.test.mock.mockito.MockBean;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.PageImpl;
 import org.springframework.http.HttpHeaders;
 import org.springframework.http.MediaType;
 import org.springframework.test.context.ActiveProfiles;
+import org.springframework.test.context.bean.override.mockito.MockitoBean;
 import org.springframework.test.web.servlet.MockMvc;
 
 @WebMvcTest(controllers = JobController.class)
@@ -46,7 +46,7 @@ class JobControllerTest {
     @Autowired
     private MockMvc mockMvc;
 
-    @MockBean
+    @MockitoBean
     private JobService jobService;
 
     @Autowired


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Refactor**
    - Updated test classes across multiple modules to use `@MockitoBean` instead of `@MockBean` for service mocking
    - Replaced mocking annotations in controller test classes for various services including `PostService`, `CustomerService`, `JobService`, and others

<!-- end of auto-generated comment: release notes by coderabbit.ai -->