### PR TITLE
feat : removes unnecessary `@AutoConfigureTestDatabase`

### DIFF
--- a/batch-boot-jpa-sample/src/test/java/com/example/bootbatchjpa/repository/SchemaValidationTest.java
+++ b/batch-boot-jpa-sample/src/test/java/com/example/bootbatchjpa/repository/SchemaValidationTest.java
@@ -7,13 +7,11 @@ import com.zaxxer.hikari.HikariDataSource;
 import javax.sql.DataSource;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
-import org.springframework.boot.test.autoconfigure.jdbc.AutoConfigureTestDatabase;
 import org.springframework.boot.test.autoconfigure.orm.jpa.DataJpaTest;
 import org.springframework.context.annotation.Import;
 
 @DataJpaTest(properties = {"spring.jpa.hibernate.ddl-auto=validate"})
 @Import(ContainersConfig.class)
-@AutoConfigureTestDatabase
 class SchemaValidationTest {
 
     @Autowired

--- a/boot-api-archunit-sample/src/test/java/com/example/archunit/SchemaValidationTest.java
+++ b/boot-api-archunit-sample/src/test/java/com/example/archunit/SchemaValidationTest.java
@@ -7,13 +7,11 @@ import com.zaxxer.hikari.HikariDataSource;
 import javax.sql.DataSource;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
-import org.springframework.boot.test.autoconfigure.jdbc.AutoConfigureTestDatabase;
 import org.springframework.boot.test.autoconfigure.orm.jpa.DataJpaTest;
 import org.springframework.context.annotation.Import;
 
 @DataJpaTest(properties = {"spring.jpa.hibernate.ddl-auto=validate"})
 @Import(ContainersConfig.class)
-@AutoConfigureTestDatabase
 class SchemaValidationTest {
 
     @Autowired

--- a/graphql/boot-graphql-webmvc/src/test/java/com/example/graphql/repositories/SchemaValidationTest.java
+++ b/graphql/boot-graphql-webmvc/src/test/java/com/example/graphql/repositories/SchemaValidationTest.java
@@ -7,12 +7,10 @@ import com.zaxxer.hikari.HikariDataSource;
 import javax.sql.DataSource;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
-import org.springframework.boot.test.autoconfigure.jdbc.AutoConfigureTestDatabase;
 import org.springframework.boot.test.autoconfigure.orm.jpa.DataJpaTest;
 import org.springframework.boot.testcontainers.context.ImportTestcontainers;
 
 @DataJpaTest(properties = {"spring.jpa.hibernate.ddl-auto=validate"})
-@AutoConfigureTestDatabase
 @ImportTestcontainers(TestContainersConfig.class)
 class SchemaValidationTest {
 

--- a/jpa/boot-data-customsequence/src/test/java/com/example/custom/sequence/SchemaValidationTest.java
+++ b/jpa/boot-data-customsequence/src/test/java/com/example/custom/sequence/SchemaValidationTest.java
@@ -8,13 +8,11 @@ import com.zaxxer.hikari.HikariDataSource;
 import javax.sql.DataSource;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
-import org.springframework.boot.test.autoconfigure.jdbc.AutoConfigureTestDatabase;
 import org.springframework.boot.test.autoconfigure.orm.jpa.DataJpaTest;
 import org.springframework.context.annotation.Import;
 
 @DataJpaTest(properties = {"spring.jpa.hibernate.ddl-auto=validate"})
 @Import({ContainersConfig.class, JpaConfig.class})
-@AutoConfigureTestDatabase
 class SchemaValidationTest {
 
     @Autowired private DataSource dataSource;

--- a/jpa/boot-jpa-locks/src/test/java/com/example/locks/SchemaValidationTest.java
+++ b/jpa/boot-jpa-locks/src/test/java/com/example/locks/SchemaValidationTest.java
@@ -7,12 +7,10 @@ import com.zaxxer.hikari.HikariDataSource;
 import javax.sql.DataSource;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
-import org.springframework.boot.test.autoconfigure.jdbc.AutoConfigureTestDatabase;
 import org.springframework.boot.test.autoconfigure.orm.jpa.DataJpaTest;
 import org.springframework.context.annotation.Import;
 
 @DataJpaTest(properties = {"spring.jpa.hibernate.ddl-auto=validate"})
-@AutoConfigureTestDatabase
 @Import(ContainersConfig.class)
 class SchemaValidationTest {
 

--- a/scheduler/boot-scheduler-quartz/src/test/java/com/scheduler/quartz/repository/SchemaValidationTest.java
+++ b/scheduler/boot-scheduler-quartz/src/test/java/com/scheduler/quartz/repository/SchemaValidationTest.java
@@ -7,13 +7,11 @@ import com.zaxxer.hikari.HikariDataSource;
 import javax.sql.DataSource;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
-import org.springframework.boot.test.autoconfigure.jdbc.AutoConfigureTestDatabase;
 import org.springframework.boot.test.autoconfigure.orm.jpa.DataJpaTest;
 import org.springframework.context.annotation.Import;
 
 @DataJpaTest(properties = {"spring.jpa.hibernate.ddl-auto=validate"})
 @Import(ContainersConfig.class)
-@AutoConfigureTestDatabase
 class SchemaValidationTest {
 
     @Autowired

--- a/scheduler/boot-scheduler-shedlock/src/test/java/com/learning/shedlock/SchemaValidationTest.java
+++ b/scheduler/boot-scheduler-shedlock/src/test/java/com/learning/shedlock/SchemaValidationTest.java
@@ -7,13 +7,11 @@ import com.zaxxer.hikari.HikariDataSource;
 import javax.sql.DataSource;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
-import org.springframework.boot.test.autoconfigure.jdbc.AutoConfigureTestDatabase;
 import org.springframework.boot.test.autoconfigure.orm.jpa.DataJpaTest;
 import org.springframework.context.annotation.Import;
 
 @DataJpaTest(properties = {"spring.jpa.hibernate.ddl-auto=validate"})
 @Import(ContainersConfig.class)
-@AutoConfigureTestDatabase
 class SchemaValidationTest {
 
     @Autowired


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Refactor**
	- Removed `@AutoConfigureTestDatabase` annotation from `SchemaValidationTest` classes across multiple projects
	- Adjusted test database configuration approach in various Spring Boot test environments

The changes suggest a standardized modification to how test databases are configured across different project repositories, potentially indicating a shift towards more explicit database testing strategies.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->