### PR TITLE
feat : use fluent setters instead of all args constructor

### DIFF
--- a/jpa/boot-data-customsequence/pom.xml
+++ b/jpa/boot-data-customsequence/pom.xml
@@ -218,10 +218,12 @@
                 <version>${spotless.version}</version>
                 <configuration>
                     <java>
-                        <googleJavaFormat>
-                            <version>1.27.0</version>
-                            <style>AOSP</style>
-                        </googleJavaFormat>
+                        <palantirJavaFormat>
+                            <version>2.67.0</version>
+                        </palantirJavaFormat>
+                        <importOrder />
+                        <removeUnusedImports />
+                        <formatAnnotations />
                     </java>
                 </configuration>
                 <executions>

--- a/jpa/boot-data-customsequence/src/main/java/com/example/custom/sequence/config/ApplicationProperties.java
+++ b/jpa/boot-data-customsequence/src/main/java/com/example/custom/sequence/config/ApplicationProperties.java
@@ -6,7 +6,8 @@ import org.springframework.boot.context.properties.NestedConfigurationProperty;
 @ConfigurationProperties("application")
 public class ApplicationProperties {
 
-    @NestedConfigurationProperty private Cors cors = new Cors();
+    @NestedConfigurationProperty
+    private Cors cors = new Cors();
 
     public Cors getCors() {
         return cors;

--- a/jpa/boot-data-customsequence/src/main/java/com/example/custom/sequence/config/SwaggerConfig.java
+++ b/jpa/boot-data-customsequence/src/main/java/com/example/custom/sequence/config/SwaggerConfig.java
@@ -6,7 +6,5 @@ import io.swagger.v3.oas.annotations.servers.Server;
 import org.springframework.context.annotation.Configuration;
 
 @Configuration(proxyBeanMethods = false)
-@OpenAPIDefinition(
-        info = @Info(title = "boot-jpa-customsequence", version = "v1"),
-        servers = @Server(url = "/"))
+@OpenAPIDefinition(info = @Info(title = "boot-jpa-customsequence", version = "v1"), servers = @Server(url = "/"))
 class SwaggerConfig {}

--- a/jpa/boot-data-customsequence/src/main/java/com/example/custom/sequence/config/db/LazyConnectionDataSourceProxyConfig.java
+++ b/jpa/boot-data-customsequence/src/main/java/com/example/custom/sequence/config/db/LazyConnectionDataSourceProxyConfig.java
@@ -37,11 +37,10 @@ class LazyConnectionDataSourceProxyConfig {
         listener.addListener(new DataSourceQueryCountListener());
 
         // Wrap with ProxyDataSource and LazyConnectionDataSourceProxy
-        DataSource loggingDataSource =
-                ProxyDataSourceBuilder.create(dataSource)
-                        .name(DATA_SOURCE_PROXY_NAME)
-                        .listener(listener)
-                        .build();
+        DataSource loggingDataSource = ProxyDataSourceBuilder.create(dataSource)
+                .name(DATA_SOURCE_PROXY_NAME)
+                .listener(listener)
+                .build();
 
         return new LazyConnectionDataSourceProxy(loggingDataSource);
     }

--- a/jpa/boot-data-customsequence/src/main/java/com/example/custom/sequence/config/db/StringPrefixedNumberFormattedSequenceIdGenerator.java
+++ b/jpa/boot-data-customsequence/src/main/java/com/example/custom/sequence/config/db/StringPrefixedNumberFormattedSequenceIdGenerator.java
@@ -18,25 +18,19 @@ public class StringPrefixedNumberFormattedSequenceIdGenerator extends SequenceSt
     private final String numberFormat;
 
     public StringPrefixedNumberFormattedSequenceIdGenerator(
-            StringPrefixedSequence config,
-            Member annotatedMember,
-            CustomIdGeneratorCreationContext context) {
+            StringPrefixedSequence config, Member annotatedMember, CustomIdGeneratorCreationContext context) {
         valuePrefix = config.valuePrefix();
         numberFormat = config.numberFormat();
     }
 
     @Override
-    public Serializable generate(SharedSessionContractImplementor session, Object object)
-            throws HibernateException {
+    public Serializable generate(SharedSessionContractImplementor session, Object object) throws HibernateException {
         return valuePrefix + numberFormat.formatted(super.generate(session, object));
     }
 
     @Override
-    public void configure(Type type, Properties params, ServiceRegistry serviceRegistry)
-            throws MappingException {
+    public void configure(Type type, Properties params, ServiceRegistry serviceRegistry) throws MappingException {
         super.configure(
-                new TypeConfiguration().getBasicTypeRegistry().getRegisteredType(Long.class),
-                params,
-                serviceRegistry);
+                new TypeConfiguration().getBasicTypeRegistry().getRegisteredType(Long.class), params, serviceRegistry);
     }
 }

--- a/jpa/boot-data-customsequence/src/main/java/com/example/custom/sequence/entities/Customer.java
+++ b/jpa/boot-data-customsequence/src/main/java/com/example/custom/sequence/entities/Customer.java
@@ -31,16 +31,6 @@ public class Customer {
 
     public Customer() {}
 
-    public Customer(String id, String text, List<Order> orders) {
-        this.id = id;
-        this.text = text;
-        this.orders = orders;
-    }
-
-    public Customer(String text) {
-        this.text = text;
-    }
-
     public String getId() {
         return id;
     }

--- a/jpa/boot-data-customsequence/src/main/java/com/example/custom/sequence/entities/Order.java
+++ b/jpa/boot-data-customsequence/src/main/java/com/example/custom/sequence/entities/Order.java
@@ -31,12 +31,6 @@ public class Order {
 
     public Order() {}
 
-    public Order(String id, String text, Customer customer) {
-        this.id = id;
-        this.text = text;
-        this.customer = customer;
-    }
-
     public String getId() {
         return id;
     }
@@ -69,8 +63,7 @@ public class Order {
         if (this == o) return true;
         if (o == null || Hibernate.getClass(this) != Hibernate.getClass(o)) return false;
         Order order = (Order) o;
-        return Objects.equals(text, order.text)
-                && Objects.equals(customer.getId(), order.customer.getId());
+        return Objects.equals(text, order.text) && Objects.equals(customer.getId(), order.customer.getId());
     }
 
     @Override

--- a/jpa/boot-data-customsequence/src/main/java/com/example/custom/sequence/exception/GlobalExceptionHandler.java
+++ b/jpa/boot-data-customsequence/src/main/java/com/example/custom/sequence/exception/GlobalExceptionHandler.java
@@ -22,23 +22,19 @@ public class GlobalExceptionHandler {
     @ResponseStatus(HttpStatus.BAD_REQUEST)
     ProblemDetail onException(MethodArgumentNotValidException methodArgumentNotValidException) {
         ProblemDetail problemDetail =
-                ProblemDetail.forStatusAndDetail(
-                        HttpStatusCode.valueOf(400), "Invalid request content.");
+                ProblemDetail.forStatusAndDetail(HttpStatusCode.valueOf(400), "Invalid request content.");
         problemDetail.setTitle("Constraint Violation");
-        List<ApiValidationError> validationErrorsList =
-                methodArgumentNotValidException.getAllErrors().stream()
-                        .map(
-                                objectError -> {
-                                    FieldError fieldError = (FieldError) objectError;
-                                    return new ApiValidationError(
-                                            fieldError.getObjectName(),
-                                            fieldError.getField(),
-                                            fieldError.getRejectedValue(),
-                                            Objects.requireNonNull(
-                                                    fieldError.getDefaultMessage(), ""));
-                                })
-                        .sorted(Comparator.comparing(ApiValidationError::field))
-                        .toList();
+        List<ApiValidationError> validationErrorsList = methodArgumentNotValidException.getAllErrors().stream()
+                .map(objectError -> {
+                    FieldError fieldError = (FieldError) objectError;
+                    return new ApiValidationError(
+                            fieldError.getObjectName(),
+                            fieldError.getField(),
+                            fieldError.getRejectedValue(),
+                            Objects.requireNonNull(fieldError.getDefaultMessage(), ""));
+                })
+                .sorted(Comparator.comparing(ApiValidationError::field))
+                .toList();
         problemDetail.setProperty("violations", validationErrorsList);
         return problemDetail;
     }

--- a/jpa/boot-data-customsequence/src/main/java/com/example/custom/sequence/mapper/CustomerMapper.java
+++ b/jpa/boot-data-customsequence/src/main/java/com/example/custom/sequence/mapper/CustomerMapper.java
@@ -23,19 +23,15 @@ public class CustomerMapper {
 
     public CustomerResponse mapToResponse(Customer saved) {
         return new CustomerResponse(
-                saved.getId(),
-                saved.getText(),
-                orderMapper.mapToResponseListWithOutCustomer(saved.getOrders()));
+                saved.getId(), saved.getText(), orderMapper.mapToResponseListWithOutCustomer(saved.getOrders()));
     }
 
     public Customer mapToEntity(CustomerRequest customerRequest) {
-        Customer customer = new Customer(customerRequest.text());
+        Customer customer = new Customer().setText(customerRequest.text());
         if (customerRequest.orders() == null) {
             return customer;
         }
-        customerRequest
-                .orders()
-                .forEach(orderRequest -> customer.addOrder(orderMapper.mapToEntity(orderRequest)));
+        customerRequest.orders().forEach(orderRequest -> customer.addOrder(orderMapper.mapToEntity(orderRequest)));
         return customer;
     }
 
@@ -45,13 +41,9 @@ public class CustomerMapper {
             return;
         }
         List<Order> removedOrders = new ArrayList<>(foundCustomer.getOrders());
-        List<Order> ordersFromRequest =
-                customerRequest.orders().stream()
-                        .map(
-                                orderRequest ->
-                                        orderMapper.mapToEntityWithCustomer(
-                                                orderRequest, foundCustomer))
-                        .collect(Collectors.toList());
+        List<Order> ordersFromRequest = customerRequest.orders().stream()
+                .map(orderRequest -> orderMapper.mapToEntityWithCustomer(orderRequest, foundCustomer))
+                .collect(Collectors.toList());
         removedOrders.removeAll(ordersFromRequest);
 
         for (Order removedOrder : removedOrders) {
@@ -74,9 +66,7 @@ public class CustomerMapper {
                 }
             }
             Order mergedOrder = orderRepository.merge(existingOrder);
-            foundCustomer
-                    .getOrders()
-                    .set(foundCustomer.getOrders().indexOf(mergedOrder), mergedOrder);
+            foundCustomer.getOrders().set(foundCustomer.getOrders().indexOf(mergedOrder), mergedOrder);
         }
 
         for (Order newOrder : newOrders) {

--- a/jpa/boot-data-customsequence/src/main/java/com/example/custom/sequence/mapper/OrderMapper.java
+++ b/jpa/boot-data-customsequence/src/main/java/com/example/custom/sequence/mapper/OrderMapper.java
@@ -15,9 +15,7 @@ public class OrderMapper {
     public OrderResponse getOrderResponse(Order order) {
         Customer customer = order.getCustomer();
         return new OrderResponse(
-                order.getId(),
-                order.getText(),
-                new CustomerResponseWithOutOrder(customer.getId(), customer.getText()));
+                order.getId(), order.getText(), new CustomerResponseWithOutOrder(customer.getId(), customer.getText()));
     }
 
     public Order mapToEntity(OrderRequest orderRequest) {

--- a/jpa/boot-data-customsequence/src/main/java/com/example/custom/sequence/model/request/CustomerRequest.java
+++ b/jpa/boot-data-customsequence/src/main/java/com/example/custom/sequence/model/request/CustomerRequest.java
@@ -5,5 +5,4 @@ import jakarta.validation.constraints.NotBlank;
 import java.util.List;
 
 public record CustomerRequest(
-        @NotBlank(message = "Text cannot be empty") String text,
-        @Valid List<OrderRequest> orders) {}
+        @NotBlank(message = "Text cannot be empty") String text, @Valid List<OrderRequest> orders) {}

--- a/jpa/boot-data-customsequence/src/main/java/com/example/custom/sequence/model/request/OrderRequest.java
+++ b/jpa/boot-data-customsequence/src/main/java/com/example/custom/sequence/model/request/OrderRequest.java
@@ -4,7 +4,4 @@ import jakarta.validation.constraints.NotBlank;
 
 public record OrderRequest(
         @NotBlank(message = "Text cannot be empty") String text,
-        @NotBlank(
-                        message = "CustomerId cannot be blank",
-                        groups = ValidationGroups.GroupCheck.class)
-                String customerId) {}
+        @NotBlank(message = "CustomerId cannot be blank", groups = ValidationGroups.GroupCheck.class) String customerId) {}

--- a/jpa/boot-data-customsequence/src/main/java/com/example/custom/sequence/model/response/CustomerResponse.java
+++ b/jpa/boot-data-customsequence/src/main/java/com/example/custom/sequence/model/response/CustomerResponse.java
@@ -9,8 +9,7 @@ import java.util.List;
  * @param text Customer's descriptive text
  * @param orderResponses List of associated orders, never null but may be empty
  */
-public record CustomerResponse(
-        String id, String text, List<OrderResponseWithOutCustomer> orderResponses) {
+public record CustomerResponse(String id, String text, List<OrderResponseWithOutCustomer> orderResponses) {
     public CustomerResponse {
         orderResponses = orderResponses == null ? List.of() : orderResponses;
     }

--- a/jpa/boot-data-customsequence/src/main/java/com/example/custom/sequence/services/CustomerService.java
+++ b/jpa/boot-data-customsequence/src/main/java/com/example/custom/sequence/services/CustomerService.java
@@ -27,18 +27,15 @@ public class CustomerService {
         this.customerMapper = customerMapper;
     }
 
-    public PagedResult<Customer> findAllCustomers(
-            int pageNo, int pageSize, String sortBy, String sortDir) {
-        Sort sort =
-                sortDir.equalsIgnoreCase(Sort.Direction.ASC.name())
-                        ? Sort.by(sortBy).ascending()
-                        : Sort.by(sortBy).descending();
+    public PagedResult<Customer> findAllCustomers(int pageNo, int pageSize, String sortBy, String sortDir) {
+        Sort sort = sortDir.equalsIgnoreCase(Sort.Direction.ASC.name())
+                ? Sort.by(sortBy).ascending()
+                : Sort.by(sortBy).descending();
 
         // create Pageable instance
         Pageable pageable = PageRequest.of(pageNo, pageSize, sort);
         Page<String> customerPage = customerRepository.findAllCustomerIds(pageable);
-        List<Customer> customersList =
-                customerRepository.findAllByIdWithOrders(customerPage.getContent());
+        List<Customer> customersList = customerRepository.findAllByIdWithOrders(customerPage.getContent());
 
         return new PagedResult<>(
                 customersList,
@@ -63,24 +60,17 @@ public class CustomerService {
     }
 
     @Transactional
-    public Optional<CustomerResponse> updateCustomerById(
-            String id, CustomerRequest customerRequest) {
-        return customerRepository
-                .findById(id)
-                .map(
-                        foundCustomer -> {
-                            customerMapper.updateCustomerFromRequest(
-                                    customerRequest, foundCustomer);
-                            return customerMapper.mapToResponse(
-                                    customerRepository.merge(foundCustomer));
-                        });
+    public Optional<CustomerResponse> updateCustomerById(String id, CustomerRequest customerRequest) {
+        return customerRepository.findById(id).map(foundCustomer -> {
+            customerMapper.updateCustomerFromRequest(customerRequest, foundCustomer);
+            return customerMapper.mapToResponse(customerRepository.merge(foundCustomer));
+        });
     }
 
     @Transactional
     public Optional<CustomerResponse> deleteCustomerById(String id) {
         Optional<CustomerResponse> optionalCustomer = findCustomerById(id);
-        optionalCustomer.ifPresent(
-                customerResponse -> customerRepository.deleteById(customerResponse.id()));
+        optionalCustomer.ifPresent(customerResponse -> customerRepository.deleteById(customerResponse.id()));
         return optionalCustomer;
     }
 

--- a/jpa/boot-data-customsequence/src/main/java/com/example/custom/sequence/services/OrderService.java
+++ b/jpa/boot-data-customsequence/src/main/java/com/example/custom/sequence/services/OrderService.java
@@ -23,28 +23,24 @@ public class OrderService {
     private final CustomerService customerService;
     private final OrderMapper orderMapper;
 
-    public OrderService(
-            OrderRepository orderRepository,
-            CustomerService customerService,
-            OrderMapper orderMapper) {
+    public OrderService(OrderRepository orderRepository, CustomerService customerService, OrderMapper orderMapper) {
         this.orderRepository = orderRepository;
         this.customerService = customerService;
         this.orderMapper = orderMapper;
     }
 
-    public PagedResult<OrderResponse> findAllOrders(
-            int pageNo, int pageSize, String sortBy, String sortDir) {
-        Sort sort =
-                sortDir.equalsIgnoreCase(Sort.Direction.ASC.name())
-                        ? Sort.by(sortBy).ascending()
-                        : Sort.by(sortBy).descending();
+    public PagedResult<OrderResponse> findAllOrders(int pageNo, int pageSize, String sortBy, String sortDir) {
+        Sort sort = sortDir.equalsIgnoreCase(Sort.Direction.ASC.name())
+                ? Sort.by(sortBy).ascending()
+                : Sort.by(sortBy).descending();
 
         // create Pageable instance
         Pageable pageable = PageRequest.of(pageNo, pageSize, sort);
         Page<Order> ordersPage = orderRepository.findAll(pageable);
 
-        List<OrderResponse> orderResponseList =
-                ordersPage.getContent().stream().map(orderMapper::getOrderResponse).toList();
+        List<OrderResponse> orderResponseList = ordersPage.getContent().stream()
+                .map(orderMapper::getOrderResponse)
+                .toList();
 
         return new PagedResult<>(
                 orderResponseList,
@@ -63,27 +59,22 @@ public class OrderService {
 
     @Transactional
     public Optional<OrderResponse> saveOrder(OrderRequest orderRequest) {
-        return customerService
-                .findById(orderRequest.customerId())
-                .map(
-                        customer -> {
-                            Order order = new Order();
-                            order.setText(orderRequest.text());
-                            order.setCustomer(customer);
-                            return orderMapper.getOrderResponse(orderRepository.persist(order));
-                        });
+        return customerService.findById(orderRequest.customerId()).map(customer -> {
+            Order order = new Order();
+            order.setText(orderRequest.text());
+            order.setCustomer(customer);
+            return orderMapper.getOrderResponse(orderRepository.persist(order));
+        });
     }
 
     @Transactional
     public Optional<OrderResponse> updateOrderById(String id, OrderRequest orderRequest) {
         return orderRepository
                 .findByIdAndCustomer_Id(id, orderRequest.customerId())
-                .map(
-                        order -> {
-                            order.setText(orderRequest.text());
-                            return orderMapper.getOrderResponse(
-                                    orderRepository.mergeAndFlush(order));
-                        });
+                .map(order -> {
+                    order.setText(orderRequest.text());
+                    return orderMapper.getOrderResponse(orderRepository.mergeAndFlush(order));
+                });
     }
 
     @Transactional

--- a/jpa/boot-data-customsequence/src/main/java/com/example/custom/sequence/web/api/CustomerAPI.java
+++ b/jpa/boot-data-customsequence/src/main/java/com/example/custom/sequence/web/api/CustomerAPI.java
@@ -76,8 +76,7 @@ public interface CustomerAPI {
                         })
             })
     ResponseEntity<CustomerResponse> getCustomerById(
-            @Parameter(name = "id", required = true, in = ParameterIn.PATH) @PathVariable
-                    String id);
+            @Parameter(name = "id", required = true, in = ParameterIn.PATH) @PathVariable String id);
 
     /**
      * POST /api/customers
@@ -93,8 +92,7 @@ public interface CustomerAPI {
                             required = true,
                             content =
                                     @Content(
-                                            schema =
-                                                    @Schema(implementation = CustomerRequest.class),
+                                            schema = @Schema(implementation = CustomerRequest.class),
                                             examples = {
                                                 @ExampleObject(
                                                         value =

--- a/jpa/boot-data-customsequence/src/main/java/com/example/custom/sequence/web/controllers/CustomerController.java
+++ b/jpa/boot-data-customsequence/src/main/java/com/example/custom/sequence/web/controllers/CustomerController.java
@@ -36,24 +36,18 @@ public class CustomerController implements CustomerAPI {
     @GetMapping
     @Override
     public PagedResult<Customer> getAllCustomers(
-            @RequestParam(defaultValue = AppConstants.DEFAULT_PAGE_NUMBER, required = false)
-                    int pageNo,
-            @RequestParam(defaultValue = AppConstants.DEFAULT_PAGE_SIZE, required = false)
-                    int pageSize,
-            @RequestParam(defaultValue = AppConstants.DEFAULT_SORT_BY, required = false)
-                    String sortBy,
-            @RequestParam(defaultValue = AppConstants.DEFAULT_SORT_DIRECTION, required = false)
-                    String sortDir) {
+            @RequestParam(defaultValue = AppConstants.DEFAULT_PAGE_NUMBER, required = false) int pageNo,
+            @RequestParam(defaultValue = AppConstants.DEFAULT_PAGE_SIZE, required = false) int pageSize,
+            @RequestParam(defaultValue = AppConstants.DEFAULT_SORT_BY, required = false) String sortBy,
+            @RequestParam(defaultValue = AppConstants.DEFAULT_SORT_DIRECTION, required = false) String sortDir) {
         return customerService.findAllCustomers(pageNo, pageSize, sortBy, sortDir);
     }
 
     @GetMapping("/{id}")
     @Override
     public ResponseEntity<CustomerResponse> getCustomerById(@PathVariable String id) {
-        return customerService
-                .findCustomerById(id)
-                .map(ResponseEntity::ok)
-                .orElseGet(() -> ResponseEntity.notFound().build());
+        return customerService.findCustomerById(id).map(ResponseEntity::ok).orElseGet(() -> ResponseEntity.notFound()
+                .build());
     }
 
     @PostMapping
@@ -78,9 +72,7 @@ public class CustomerController implements CustomerAPI {
 
     @DeleteMapping("/{id}")
     public ResponseEntity<CustomerResponse> deleteCustomer(@PathVariable String id) {
-        return customerService
-                .deleteCustomerById(id)
-                .map(ResponseEntity::ok)
-                .orElseGet(() -> ResponseEntity.notFound().build());
+        return customerService.deleteCustomerById(id).map(ResponseEntity::ok).orElseGet(() -> ResponseEntity.notFound()
+                .build());
     }
 }

--- a/jpa/boot-data-customsequence/src/main/java/com/example/custom/sequence/web/controllers/OrderController.java
+++ b/jpa/boot-data-customsequence/src/main/java/com/example/custom/sequence/web/controllers/OrderController.java
@@ -32,23 +32,17 @@ public class OrderController {
 
     @GetMapping
     public PagedResult<OrderResponse> getAllOrders(
-            @RequestParam(defaultValue = AppConstants.DEFAULT_PAGE_NUMBER, required = false)
-                    int pageNo,
-            @RequestParam(defaultValue = AppConstants.DEFAULT_PAGE_SIZE, required = false)
-                    int pageSize,
-            @RequestParam(defaultValue = AppConstants.DEFAULT_SORT_BY, required = false)
-                    String sortBy,
-            @RequestParam(defaultValue = AppConstants.DEFAULT_SORT_DIRECTION, required = false)
-                    String sortDir) {
+            @RequestParam(defaultValue = AppConstants.DEFAULT_PAGE_NUMBER, required = false) int pageNo,
+            @RequestParam(defaultValue = AppConstants.DEFAULT_PAGE_SIZE, required = false) int pageSize,
+            @RequestParam(defaultValue = AppConstants.DEFAULT_SORT_BY, required = false) String sortBy,
+            @RequestParam(defaultValue = AppConstants.DEFAULT_SORT_DIRECTION, required = false) String sortDir) {
         return orderService.findAllOrders(pageNo, pageSize, sortBy, sortDir);
     }
 
     @GetMapping("/{id}")
     public ResponseEntity<OrderResponse> getOrderById(@PathVariable String id) {
-        return orderService
-                .findOrderById(id)
-                .map(ResponseEntity::ok)
-                .orElseGet(() -> ResponseEntity.notFound().build());
+        return orderService.findOrderById(id).map(ResponseEntity::ok).orElseGet(() -> ResponseEntity.notFound()
+                .build());
     }
 
     @PostMapping
@@ -76,11 +70,10 @@ public class OrderController {
     public ResponseEntity<OrderResponse> deleteOrder(@PathVariable String id) {
         return orderService
                 .findOrderById(id)
-                .map(
-                        order -> {
-                            orderService.deleteOrderById(id);
-                            return ResponseEntity.ok(order);
-                        })
+                .map(order -> {
+                    orderService.deleteOrderById(id);
+                    return ResponseEntity.ok(order);
+                })
                 .orElseGet(() -> ResponseEntity.notFound().build());
     }
 }

--- a/jpa/boot-data-customsequence/src/test/java/com/example/custom/sequence/SchemaValidationTest.java
+++ b/jpa/boot-data-customsequence/src/test/java/com/example/custom/sequence/SchemaValidationTest.java
@@ -15,7 +15,8 @@ import org.springframework.context.annotation.Import;
 @Import({ContainersConfig.class, JpaConfig.class})
 class SchemaValidationTest {
 
-    @Autowired private DataSource dataSource;
+    @Autowired
+    private DataSource dataSource;
 
     @Test
     void validateJpaMappingsWithDbSchema() {

--- a/jpa/boot-data-customsequence/src/test/java/com/example/custom/sequence/TestCustomSeqApplication.java
+++ b/jpa/boot-data-customsequence/src/test/java/com/example/custom/sequence/TestCustomSeqApplication.java
@@ -6,6 +6,8 @@ import org.springframework.boot.SpringApplication;
 public class TestCustomSeqApplication {
 
     public static void main(String[] args) {
-        SpringApplication.from(CustomSeqApplication::main).with(ContainersConfig.class).run(args);
+        SpringApplication.from(CustomSeqApplication::main)
+                .with(ContainersConfig.class)
+                .run(args);
     }
 }

--- a/jpa/boot-data-customsequence/src/test/java/com/example/custom/sequence/common/AbstractIntegrationTest.java
+++ b/jpa/boot-data-customsequence/src/test/java/com/example/custom/sequence/common/AbstractIntegrationTest.java
@@ -23,9 +23,12 @@ import org.springframework.test.web.servlet.assertj.MockMvcTester;
 @AutoConfigureMockMvc
 public abstract class AbstractIntegrationTest {
 
-    @Autowired protected MockMvcTester mockMvcTester;
+    @Autowired
+    protected MockMvcTester mockMvcTester;
 
-    @Autowired protected ObjectMapper objectMapper;
+    @Autowired
+    protected ObjectMapper objectMapper;
 
-    @Autowired protected DataSource dataSource;
+    @Autowired
+    protected DataSource dataSource;
 }

--- a/jpa/boot-data-customsequence/src/test/java/com/example/custom/sequence/common/ContainersConfig.java
+++ b/jpa/boot-data-customsequence/src/test/java/com/example/custom/sequence/common/ContainersConfig.java
@@ -12,6 +12,6 @@ public class ContainersConfig {
     @Bean
     @ServiceConnection
     MariaDBContainer<?> mariaDbContainer() {
-        return new MariaDBContainer<>(DockerImageName.parse("mariadb").withTag("11.7"));
+        return new MariaDBContainer<>(DockerImageName.parse("mariadb").withTag("11.8"));
     }
 }

--- a/jpa/boot-data-customsequence/src/test/java/com/example/custom/sequence/services/CustomerServiceTest.java
+++ b/jpa/boot-data-customsequence/src/test/java/com/example/custom/sequence/services/CustomerServiceTest.java
@@ -27,19 +27,21 @@ import org.springframework.data.domain.Sort;
 @ExtendWith(MockitoExtension.class)
 class CustomerServiceTest {
 
-    @Mock private CustomerRepository customerRepository;
-    @Mock private CustomerMapper customerMapper;
+    @Mock
+    private CustomerRepository customerRepository;
 
-    @InjectMocks private CustomerService customerService;
+    @Mock
+    private CustomerMapper customerMapper;
+
+    @InjectMocks
+    private CustomerService customerService;
 
     @Test
     void findAllCustomers() {
         // given
         Pageable pageable = PageRequest.of(0, 10, Sort.by(Sort.Direction.ASC, "id"));
-        given(customerRepository.findAllCustomerIds(pageable))
-                .willReturn(new PageImpl<>(List.of("CUS_1")));
-        given(customerRepository.findAllByIdWithOrders(List.of("CUS_1")))
-                .willReturn(List.of(getCustomer()));
+        given(customerRepository.findAllCustomerIds(pageable)).willReturn(new PageImpl<>(List.of("CUS_1")));
+        given(customerRepository.findAllByIdWithOrders(List.of("CUS_1"))).willReturn(List.of(getCustomer()));
 
         // when
         PagedResult<Customer> pagedResult = customerService.findAllCustomers(0, 10, "id", "asc");
@@ -112,8 +114,6 @@ class CustomerServiceTest {
 
     private CustomerResponse getCustomerResponse() {
         return new CustomerResponse(
-                "CUS_1",
-                "junitTest",
-                List.of(new OrderResponseWithOutCustomer("ORD_1", "junitTest")));
+                "CUS_1", "junitTest", List.of(new OrderResponseWithOutCustomer("ORD_1", "junitTest")));
     }
 }

--- a/jpa/boot-data-customsequence/src/test/java/com/example/custom/sequence/services/OrderServiceTest.java
+++ b/jpa/boot-data-customsequence/src/test/java/com/example/custom/sequence/services/OrderServiceTest.java
@@ -32,11 +32,17 @@ import org.springframework.data.domain.Sort;
 @ExtendWith(MockitoExtension.class)
 class OrderServiceTest {
 
-    @Mock private OrderRepository orderRepository;
-    @Mock private CustomerService customerService;
-    @Mock private OrderMapper orderMapper;
+    @Mock
+    private OrderRepository orderRepository;
 
-    @InjectMocks private OrderService orderService;
+    @Mock
+    private CustomerService customerService;
+
+    @Mock
+    private OrderMapper orderMapper;
+
+    @InjectMocks
+    private OrderService orderService;
 
     @Test
     void findAllOrders() {
@@ -78,7 +84,8 @@ class OrderServiceTest {
     void saveOrder() {
         // given
         given(customerService.findById("1"))
-                .willReturn(Optional.of(new Customer("1", "custText", List.of())));
+                .willReturn(Optional.of(
+                        new Customer().setId("1").setText("custText").setOrders(List.of())));
         given(orderRepository.persist(getOrder())).willReturn(getOrder());
         given(orderMapper.getOrderResponse(getOrder())).willReturn(getOrderResponse());
         // when
@@ -124,8 +131,7 @@ class OrderServiceTest {
     }
 
     private OrderResponse getOrderResponse() {
-        return new OrderResponse(
-                "1", "junitText", new CustomerResponseWithOutOrder("1", "custText"));
+        return new OrderResponse("1", "junitText", new CustomerResponseWithOutOrder("1", "custText"));
     }
 
     private OrderRequest getOrderReq() {

--- a/jpa/boot-data-customsequence/src/test/java/com/example/custom/sequence/web/controllers/CustomerControllerIT.java
+++ b/jpa/boot-data-customsequence/src/test/java/com/example/custom/sequence/web/controllers/CustomerControllerIT.java
@@ -24,7 +24,8 @@ import org.springframework.http.ProblemDetail;
 
 class CustomerControllerIT extends AbstractIntegrationTest {
 
-    @Autowired private CustomerRepository customerRepository;
+    @Autowired
+    private CustomerRepository customerRepository;
 
     private List<Customer> customerList = null;
 
@@ -33,9 +34,9 @@ class CustomerControllerIT extends AbstractIntegrationTest {
         customerRepository.deleteAllInBatch();
 
         customerList = new ArrayList<>();
-        customerList.add(new Customer("First Customer"));
-        customerList.add(new Customer("Second Customer"));
-        customerList.add(new Customer("Third Customer"));
+        customerList.add(new Customer().setText("First Customer"));
+        customerList.add(new Customer().setText("Second Customer"));
+        customerList.add(new Customer().setText("Third Customer"));
         customerList = customerRepository.persistAll(customerList);
 
         SQLStatementCountValidator.reset();
@@ -52,17 +53,16 @@ class CustomerControllerIT extends AbstractIntegrationTest {
                 .hasContentType(MediaType.APPLICATION_JSON)
                 .bodyJson()
                 .convertTo(PagedResult.class)
-                .satisfies(
-                        pagedResult -> {
-                            assertThat(pagedResult.data()).hasSize(3);
-                            assertThat(pagedResult.totalElements()).isEqualTo(3);
-                            assertThat(pagedResult.pageNumber()).isEqualTo(1);
-                            assertThat(pagedResult.totalPages()).isEqualTo(1);
-                            assertThat(pagedResult.isFirst()).isTrue();
-                            assertThat(pagedResult.isLast()).isTrue();
-                            assertThat(pagedResult.hasNext()).isFalse();
-                            assertThat(pagedResult.hasPrevious()).isFalse();
-                        });
+                .satisfies(pagedResult -> {
+                    assertThat(pagedResult.data()).hasSize(3);
+                    assertThat(pagedResult.totalElements()).isEqualTo(3);
+                    assertThat(pagedResult.pageNumber()).isEqualTo(1);
+                    assertThat(pagedResult.totalPages()).isEqualTo(1);
+                    assertThat(pagedResult.isFirst()).isTrue();
+                    assertThat(pagedResult.isLast()).isTrue();
+                    assertThat(pagedResult.hasNext()).isFalse();
+                    assertThat(pagedResult.hasPrevious()).isFalse();
+                });
 
         SQLStatementCountValidator.assertSelectCount(2);
         SQLStatementCountValidator.assertTotalCount(2);
@@ -81,12 +81,11 @@ class CustomerControllerIT extends AbstractIntegrationTest {
                 .hasContentType(MediaType.APPLICATION_JSON)
                 .bodyJson()
                 .convertTo(CustomerResponse.class)
-                .satisfies(
-                        customerResponse -> {
-                            assertThat(customerResponse.id()).isEqualTo(customer.getId());
-                            assertThat(customerResponse.text()).isEqualTo(customer.getText());
-                            assertThat(customerResponse.orderResponses()).isEmpty();
-                        });
+                .satisfies(customerResponse -> {
+                    assertThat(customerResponse.id()).isEqualTo(customer.getId());
+                    assertThat(customerResponse.text()).isEqualTo(customer.getText());
+                    assertThat(customerResponse.orderResponses()).isEmpty();
+                });
 
         SQLStatementCountValidator.assertSelectCount(1);
         SQLStatementCountValidator.assertTotalCount(1);
@@ -106,12 +105,11 @@ class CustomerControllerIT extends AbstractIntegrationTest {
                 .hasContentType(MediaType.APPLICATION_JSON)
                 .bodyJson()
                 .convertTo(CustomerResponse.class)
-                .satisfies(
-                        customerResponse -> {
-                            assertThat(customerResponse.id()).startsWith("CUS").hasSize(8);
-                            assertThat(customerResponse.text()).isEqualTo(customerRequest.text());
-                            assertThat(customerResponse.orderResponses()).isEmpty();
-                        });
+                .satisfies(customerResponse -> {
+                    assertThat(customerResponse.id()).startsWith("CUS").hasSize(8);
+                    assertThat(customerResponse.text()).isEqualTo(customerRequest.text());
+                    assertThat(customerResponse.orderResponses()).isEmpty();
+                });
 
         SQLStatementCountValidator.assertSelectCount(0);
         SQLStatementCountValidator.assertInsertCount(1);
@@ -122,8 +120,7 @@ class CustomerControllerIT extends AbstractIntegrationTest {
 
     @Test
     void shouldReturn400WhenCreateNewCustomerWithoutText() throws JsonProcessingException {
-        CustomerRequest customerRequest =
-                new CustomerRequest(null, List.of(new OrderRequest("First Order", null)));
+        CustomerRequest customerRequest = new CustomerRequest(null, List.of(new OrderRequest("First Order", null)));
 
         this.mockMvcTester
                 .post()
@@ -135,29 +132,24 @@ class CustomerControllerIT extends AbstractIntegrationTest {
                 .hasContentType(MediaType.APPLICATION_PROBLEM_JSON)
                 .bodyJson()
                 .convertTo(ProblemDetail.class)
-                .satisfies(
-                        errorResponse -> {
-                            assertThat(errorResponse.getType().toString()).isEqualTo("about:blank");
-                            assertThat(errorResponse.getTitle()).isEqualTo("Constraint Violation");
-                            assertThat(errorResponse.getStatus()).isEqualTo(400);
-                            assertThat(errorResponse.getDetail())
-                                    .isEqualTo("Invalid request content.");
-                            assertThat(
-                                            Objects.requireNonNull(errorResponse.getInstance())
-                                                    .toString())
-                                    .isEqualTo("/api/customers");
-                            assertThat(errorResponse.getProperties()).hasSize(1);
-                            Object violations = errorResponse.getProperties().get("violations");
-                            assertThat(violations).isNotNull();
-                            assertThat(violations).isInstanceOf(List.class);
-                            assertThat((List<?>) violations).hasSize(1);
-                            assertThat(((List<?>) violations).getFirst())
-                                    .isInstanceOf(LinkedHashMap.class);
-                            LinkedHashMap<?, ?> violation =
-                                    (LinkedHashMap<?, ?>) ((List<?>) violations).getFirst();
-                            assertThat(violation.get("field")).isEqualTo("text");
-                            assertThat(violation.get("message")).isEqualTo("Text cannot be empty");
-                        });
+                .satisfies(errorResponse -> {
+                    assertThat(errorResponse.getType().toString()).isEqualTo("about:blank");
+                    assertThat(errorResponse.getTitle()).isEqualTo("Constraint Violation");
+                    assertThat(errorResponse.getStatus()).isEqualTo(400);
+                    assertThat(errorResponse.getDetail()).isEqualTo("Invalid request content.");
+                    assertThat(Objects.requireNonNull(errorResponse.getInstance())
+                                    .toString())
+                            .isEqualTo("/api/customers");
+                    assertThat(errorResponse.getProperties()).hasSize(1);
+                    Object violations = errorResponse.getProperties().get("violations");
+                    assertThat(violations).isNotNull();
+                    assertThat(violations).isInstanceOf(List.class);
+                    assertThat((List<?>) violations).hasSize(1);
+                    assertThat(((List<?>) violations).getFirst()).isInstanceOf(LinkedHashMap.class);
+                    LinkedHashMap<?, ?> violation = (LinkedHashMap<?, ?>) ((List<?>) violations).getFirst();
+                    assertThat(violation.get("field")).isEqualTo("text");
+                    assertThat(violation.get("message")).isEqualTo("Text cannot be empty");
+                });
 
         SQLStatementCountValidator.assertTotalCount(0);
 
@@ -179,11 +171,10 @@ class CustomerControllerIT extends AbstractIntegrationTest {
                 .hasContentType(MediaType.APPLICATION_JSON)
                 .bodyJson()
                 .convertTo(CustomerResponse.class)
-                .satisfies(
-                        customerResponse -> {
-                            assertThat(customerResponse.text()).isEqualTo("Updated Customer");
-                            assertThat(customerResponse.orderResponses()).isEmpty();
-                        });
+                .satisfies(customerResponse -> {
+                    assertThat(customerResponse.text()).isEqualTo("Updated Customer");
+                    assertThat(customerResponse.orderResponses()).isEmpty();
+                });
 
         // select for customer
         SQLStatementCountValidator.assertSelectCount(1);
@@ -210,11 +201,10 @@ class CustomerControllerIT extends AbstractIntegrationTest {
                 .hasStatusOk()
                 .bodyJson()
                 .convertTo(CustomerResponse.class)
-                .satisfies(
-                        customerResponse -> {
-                            assertThat(customerResponse.text()).isEqualTo("Updated Customer1");
-                            assertThat(customerResponse.orderResponses()).isNotEmpty().hasSize(2);
-                        });
+                .satisfies(customerResponse -> {
+                    assertThat(customerResponse.text()).isEqualTo("Updated Customer1");
+                    assertThat(customerResponse.orderResponses()).isNotEmpty().hasSize(2);
+                });
         // select for customer and 2 for orders sequence
         SQLStatementCountValidator.assertSelectCount(3);
         // update for customer table
@@ -241,11 +231,10 @@ class CustomerControllerIT extends AbstractIntegrationTest {
                 .hasStatusOk()
                 .bodyJson()
                 .convertTo(CustomerResponse.class)
-                .satisfies(
-                        customerResponse -> {
-                            assertThat(customerResponse.text()).isEqualTo("Updated Customer1");
-                            assertThat(customerResponse.orderResponses()).isNotEmpty().hasSize(2);
-                        });
+                .satisfies(customerResponse -> {
+                    assertThat(customerResponse.text()).isEqualTo("Updated Customer1");
+                    assertThat(customerResponse.orderResponses()).isNotEmpty().hasSize(2);
+                });
         // select for customer
         SQLStatementCountValidator.assertSelectCount(1);
         // update for customer table
@@ -269,8 +258,7 @@ class CustomerControllerIT extends AbstractIntegrationTest {
                 .bodyJson()
                 .convertTo(CustomerResponse.class)
                 .satisfies(
-                        customerResponse ->
-                                assertThat(customerResponse.text()).isEqualTo(customer.getText()));
+                        customerResponse -> assertThat(customerResponse.text()).isEqualTo(customer.getText()));
 
         // select for customer
         SQLStatementCountValidator.assertSelectCount(1);

--- a/jpa/boot-data-customsequence/src/test/java/com/example/custom/sequence/web/controllers/CustomerControllerTest.java
+++ b/jpa/boot-data-customsequence/src/test/java/com/example/custom/sequence/web/controllers/CustomerControllerTest.java
@@ -40,20 +40,23 @@ import org.springframework.test.web.servlet.MockMvc;
 @ActiveProfiles(PROFILE_TEST)
 class CustomerControllerTest {
 
-    @Autowired private MockMvc mockMvc;
+    @Autowired
+    private MockMvc mockMvc;
 
-    @MockitoBean private CustomerService customerService;
+    @MockitoBean
+    private CustomerService customerService;
 
-    @Autowired private ObjectMapper objectMapper;
+    @Autowired
+    private ObjectMapper objectMapper;
 
     private List<Customer> customerList;
 
     @BeforeEach
     void setUp() {
         this.customerList = new ArrayList<>();
-        this.customerList.add(new Customer("CUS_1", "text 1", new ArrayList<>()));
-        this.customerList.add(new Customer("CUS_2", "text 2", new ArrayList<>()));
-        this.customerList.add(new Customer("CUS_3", "text 3", new ArrayList<>()));
+        this.customerList.add(new Customer().setId("CUS_1").setText("text 1").setOrders(new ArrayList<>()));
+        this.customerList.add(new Customer().setId("CUS_2").setText("text 2").setOrders(new ArrayList<>()));
+        this.customerList.add(new Customer().setId("CUS_3").setText("text 3").setOrders(new ArrayList<>()));
     }
 
     @Test
@@ -92,9 +95,7 @@ class CustomerControllerTest {
         String customerId = "CUS_1";
         given(customerService.findCustomerById(customerId)).willReturn(Optional.empty());
 
-        this.mockMvc
-                .perform(get("/api/customers/{id}", customerId))
-                .andExpect(status().isNotFound());
+        this.mockMvc.perform(get("/api/customers/{id}", customerId)).andExpect(status().isNotFound());
     }
 
     @Test
@@ -106,10 +107,9 @@ class CustomerControllerTest {
                 .willReturn(new CustomerResponse("CUS_1", "some text", List.of()));
 
         this.mockMvc
-                .perform(
-                        post("/api/customers")
-                                .contentType(MediaType.APPLICATION_JSON)
-                                .content(objectMapper.writeValueAsString(customerRequest)))
+                .perform(post("/api/customers")
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(objectMapper.writeValueAsString(customerRequest)))
                 .andExpect(status().isCreated())
                 .andExpect(jsonPath("$.id", notNullValue()))
                 .andExpect(jsonPath("$.text", is(customerRequest.text())));
@@ -117,14 +117,12 @@ class CustomerControllerTest {
 
     @Test
     void shouldReturn400WhenCreateNewCustomerWithInvalidData() throws Exception {
-        CustomerRequest customerRequest =
-                new CustomerRequest(null, List.of(new OrderRequest("ORD_1", null)));
+        CustomerRequest customerRequest = new CustomerRequest(null, List.of(new OrderRequest("ORD_1", null)));
 
         this.mockMvc
-                .perform(
-                        post("/api/customers")
-                                .contentType(MediaType.APPLICATION_JSON)
-                                .content(objectMapper.writeValueAsString(customerRequest)))
+                .perform(post("/api/customers")
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(objectMapper.writeValueAsString(customerRequest)))
                 .andExpect(status().isBadRequest())
                 .andExpect(header().string("Content-Type", is("application/problem+json")))
                 .andExpect(jsonPath("$.type", is("about:blank")))
@@ -142,10 +140,9 @@ class CustomerControllerTest {
     void shouldReturn400WhenCreateNewCustomerWithEmptyText() throws Exception {
         CustomerRequest customerRequest = new CustomerRequest("", new ArrayList<>());
         this.mockMvc
-                .perform(
-                        post("/api/customers")
-                                .contentType(MediaType.APPLICATION_JSON)
-                                .content(objectMapper.writeValueAsString(customerRequest)))
+                .perform(post("/api/customers")
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(objectMapper.writeValueAsString(customerRequest)))
                 .andExpect(status().isBadRequest())
                 .andExpect(header().string("Content-Type", is("application/problem+json")))
                 .andExpect(jsonPath("$.type", is("about:blank")))
@@ -161,21 +158,17 @@ class CustomerControllerTest {
     @Test
     void shouldUpdateCustomer() throws Exception {
         String customerId = "CUS_1";
-        CustomerResponse customerResponse =
-                new CustomerResponse(
-                        customerId,
-                        "Updated text",
-                        List.of(new OrderResponseWithOutCustomer("ORD_1", "New Order")));
+        CustomerResponse customerResponse = new CustomerResponse(
+                customerId, "Updated text", List.of(new OrderResponseWithOutCustomer("ORD_1", "New Order")));
         CustomerRequest customerRequest =
                 new CustomerRequest("Updated text", List.of(new OrderRequest("ORD_1", customerId)));
         given(customerService.updateCustomerById(customerId, customerRequest))
                 .willReturn(Optional.of(customerResponse));
 
         this.mockMvc
-                .perform(
-                        put("/api/customers/{id}", customerId)
-                                .contentType(MediaType.APPLICATION_JSON)
-                                .content(objectMapper.writeValueAsString(customerRequest)))
+                .perform(put("/api/customers/{id}", customerId)
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(objectMapper.writeValueAsString(customerRequest)))
                 .andExpect(status().isOk())
                 .andExpect(jsonPath("$.text", is(customerResponse.text())))
                 .andExpect(jsonPath("$.orderResponses", hasSize(1)))
@@ -186,14 +179,12 @@ class CustomerControllerTest {
     @Test
     void shouldReturn400WhenUpdateCustomerWithEmpty() throws Exception {
         String customerId = "CUS_1";
-        CustomerRequest customerRequest =
-                new CustomerRequest("Updated text", List.of(new OrderRequest("ORD_1", null)));
+        CustomerRequest customerRequest = new CustomerRequest("Updated text", List.of(new OrderRequest("ORD_1", null)));
 
         this.mockMvc
-                .perform(
-                        put("/api/customers/{id}", customerId)
-                                .contentType(MediaType.APPLICATION_JSON)
-                                .content(objectMapper.writeValueAsString(customerRequest)))
+                .perform(put("/api/customers/{id}", customerId)
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(objectMapper.writeValueAsString(customerRequest)))
                 .andExpect(status().isBadRequest())
                 .andExpect(header().string("Content-Type", is("application/problem+json")))
                 .andExpect(jsonPath("$.type", is("about:blank")))
@@ -210,23 +201,20 @@ class CustomerControllerTest {
     void shouldReturn404WhenUpdatingNonExistingCustomer() throws Exception {
         String customerId = "CUS_1";
         given(customerService.findCustomerById(customerId)).willReturn(Optional.empty());
-        Customer customer = new Customer(customerId, "Updated text", new ArrayList<>());
+        Customer customer = new Customer().setId(customerId).setText("Updated text");
 
         this.mockMvc
-                .perform(
-                        put("/api/customers/{id}", customerId)
-                                .contentType(MediaType.APPLICATION_JSON)
-                                .content(objectMapper.writeValueAsString(customer)))
+                .perform(put("/api/customers/{id}", customerId)
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(objectMapper.writeValueAsString(customer)))
                 .andExpect(status().isNotFound());
     }
 
     @Test
     void shouldDeleteCustomer() throws Exception {
         String customerId = "CUS_1";
-        CustomerResponse customerResponse =
-                new CustomerResponse(customerId, "Some text", List.of());
-        given(customerService.deleteCustomerById(customerId))
-                .willReturn(Optional.of(customerResponse));
+        CustomerResponse customerResponse = new CustomerResponse(customerId, "Some text", List.of());
+        given(customerService.deleteCustomerById(customerId)).willReturn(Optional.of(customerResponse));
 
         this.mockMvc
                 .perform(delete("/api/customers/{id}", customerId))
@@ -239,8 +227,6 @@ class CustomerControllerTest {
         String customerId = "CUS_1";
         given(customerService.deleteCustomerById(customerId)).willReturn(Optional.empty());
 
-        this.mockMvc
-                .perform(delete("/api/customers/{id}", customerId))
-                .andExpect(status().isNotFound());
+        this.mockMvc.perform(delete("/api/customers/{id}", customerId)).andExpect(status().isNotFound());
     }
 }

--- a/jpa/boot-data-customsequence/src/test/java/com/example/custom/sequence/web/controllers/OrderControllerIT.java
+++ b/jpa/boot-data-customsequence/src/test/java/com/example/custom/sequence/web/controllers/OrderControllerIT.java
@@ -22,8 +22,11 @@ import org.springframework.http.ProblemDetail;
 
 class OrderControllerIT extends AbstractIntegrationTest {
 
-    @Autowired private OrderRepository orderRepository;
-    @Autowired private CustomerRepository customerRepository;
+    @Autowired
+    private OrderRepository orderRepository;
+
+    @Autowired
+    private CustomerRepository customerRepository;
 
     private List<Order> orderList = null;
     private Customer customer;
@@ -37,15 +40,14 @@ class OrderControllerIT extends AbstractIntegrationTest {
     }
 
     private Customer createTestCustomer() {
-        return customerRepository.persist(new Customer("customer1"));
+        return customerRepository.persist(new Customer().setText("customer1"));
     }
 
     private List<Order> createTestOrders(Customer customer) {
-        List<Order> orders =
-                List.of(
-                        new Order(null, "First Order", customer),
-                        new Order(null, "Second Order", customer),
-                        new Order(null, "Third Order", customer));
+        List<Order> orders = List.of(
+                new Order().setText("First Order").setCustomer(customer),
+                new Order().setText("Second Order").setCustomer(customer),
+                new Order().setText("Third Order").setCustomer(customer));
         return orderRepository.persistAll(orders);
     }
 
@@ -60,17 +62,16 @@ class OrderControllerIT extends AbstractIntegrationTest {
                 .hasContentType(MediaType.APPLICATION_JSON)
                 .bodyJson()
                 .convertTo(PagedResult.class)
-                .satisfies(
-                        pagedResult -> {
-                            assertThat(pagedResult.data()).hasSize(3);
-                            assertThat(pagedResult.totalElements()).isEqualTo(3);
-                            assertThat(pagedResult.pageNumber()).isEqualTo(1);
-                            assertThat(pagedResult.totalPages()).isEqualTo(1);
-                            assertThat(pagedResult.isFirst()).isTrue();
-                            assertThat(pagedResult.isLast()).isTrue();
-                            assertThat(pagedResult.hasNext()).isFalse();
-                            assertThat(pagedResult.hasPrevious()).isFalse();
-                        });
+                .satisfies(pagedResult -> {
+                    assertThat(pagedResult.data()).hasSize(3);
+                    assertThat(pagedResult.totalElements()).isEqualTo(3);
+                    assertThat(pagedResult.pageNumber()).isEqualTo(1);
+                    assertThat(pagedResult.totalPages()).isEqualTo(1);
+                    assertThat(pagedResult.isFirst()).isTrue();
+                    assertThat(pagedResult.isLast()).isTrue();
+                    assertThat(pagedResult.hasNext()).isFalse();
+                    assertThat(pagedResult.hasPrevious()).isFalse();
+                });
     }
 
     @Test
@@ -86,11 +87,10 @@ class OrderControllerIT extends AbstractIntegrationTest {
                 .hasContentType(MediaType.APPLICATION_JSON)
                 .bodyJson()
                 .convertTo(OrderResponse.class)
-                .satisfies(
-                        orderResponse -> {
-                            assertThat(orderResponse.id()).isEqualTo(orderId);
-                            assertThat(orderResponse.text()).isEqualTo(order.getText());
-                        });
+                .satisfies(orderResponse -> {
+                    assertThat(orderResponse.id()).isEqualTo(orderId);
+                    assertThat(orderResponse.text()).isEqualTo(order.getText());
+                });
     }
 
     @Test
@@ -107,11 +107,10 @@ class OrderControllerIT extends AbstractIntegrationTest {
                 .hasContentType(MediaType.APPLICATION_JSON)
                 .bodyJson()
                 .convertTo(OrderResponse.class)
-                .satisfies(
-                        orderResponse -> {
-                            assertThat(orderResponse.id()).isNotNull().hasSize(9);
-                            assertThat(orderResponse.text()).isEqualTo(orderRequest.text());
-                        });
+                .satisfies(orderResponse -> {
+                    assertThat(orderResponse.id()).isNotNull().hasSize(9);
+                    assertThat(orderResponse.text()).isEqualTo(orderRequest.text());
+                });
     }
 
     @Test
@@ -128,26 +127,23 @@ class OrderControllerIT extends AbstractIntegrationTest {
                 .hasContentType(MediaType.APPLICATION_PROBLEM_JSON)
                 .bodyJson()
                 .convertTo(ProblemDetail.class)
-                .satisfies(
-                        problem -> {
-                            assertThat(problem.getType().toString()).isEqualTo("about:blank");
-                            assertThat(problem.getTitle()).isEqualTo("Constraint Violation");
-                            assertThat(problem.getStatus()).isEqualTo(400);
-                            assertThat(problem.getDetail()).isEqualTo("Invalid request content.");
-                            assertThat(Objects.requireNonNull(problem.getInstance()).toString())
-                                    .isEqualTo("/api/orders");
-                            assertThat(problem.getProperties()).hasSize(1);
-                            Object violations = problem.getProperties().get("violations");
-                            assertThat(violations).isNotNull();
-                            assertThat(violations).isInstanceOf(List.class);
-                            assertThat((List<?>) violations).hasSize(1);
-                            assertThat(((List<?>) violations).getFirst())
-                                    .isInstanceOf(LinkedHashMap.class);
-                            LinkedHashMap<?, ?> violation =
-                                    (LinkedHashMap<?, ?>) ((List<?>) violations).getFirst();
-                            assertThat(violation.get("field")).isEqualTo("text");
-                            assertThat(violation.get("message")).isEqualTo("Text cannot be empty");
-                        });
+                .satisfies(problem -> {
+                    assertThat(problem.getType().toString()).isEqualTo("about:blank");
+                    assertThat(problem.getTitle()).isEqualTo("Constraint Violation");
+                    assertThat(problem.getStatus()).isEqualTo(400);
+                    assertThat(problem.getDetail()).isEqualTo("Invalid request content.");
+                    assertThat(Objects.requireNonNull(problem.getInstance()).toString())
+                            .isEqualTo("/api/orders");
+                    assertThat(problem.getProperties()).hasSize(1);
+                    Object violations = problem.getProperties().get("violations");
+                    assertThat(violations).isNotNull();
+                    assertThat(violations).isInstanceOf(List.class);
+                    assertThat((List<?>) violations).hasSize(1);
+                    assertThat(((List<?>) violations).getFirst()).isInstanceOf(LinkedHashMap.class);
+                    LinkedHashMap<?, ?> violation = (LinkedHashMap<?, ?>) ((List<?>) violations).getFirst();
+                    assertThat(violation.get("field")).isEqualTo("text");
+                    assertThat(violation.get("message")).isEqualTo("Text cannot be empty");
+                });
     }
 
     @Test
@@ -165,11 +161,10 @@ class OrderControllerIT extends AbstractIntegrationTest {
                 .hasContentType(MediaType.APPLICATION_JSON)
                 .bodyJson()
                 .convertTo(OrderResponse.class)
-                .satisfies(
-                        orderResponse -> {
-                            assertThat(orderResponse.id()).isEqualTo(order.getId());
-                            assertThat(orderResponse.text()).isEqualTo(orderRequest.text());
-                        });
+                .satisfies(orderResponse -> {
+                    assertThat(orderResponse.id()).isEqualTo(order.getId());
+                    assertThat(orderResponse.text()).isEqualTo(orderRequest.text());
+                });
     }
 
     @Test
@@ -212,11 +207,10 @@ class OrderControllerIT extends AbstractIntegrationTest {
                 .hasContentType(MediaType.APPLICATION_JSON)
                 .bodyJson()
                 .convertTo(OrderResponse.class)
-                .satisfies(
-                        orderResponse -> {
-                            assertThat(orderResponse.id()).isEqualTo(orderId);
-                            assertThat(orderResponse.text()).isEqualTo(order.getText());
-                        });
+                .satisfies(orderResponse -> {
+                    assertThat(orderResponse.id()).isEqualTo(orderId);
+                    assertThat(orderResponse.text()).isEqualTo(order.getText());
+                });
 
         // Verify order is deleted from database
         assertThat(orderRepository.findById(orderId)).isEmpty();

--- a/jpa/boot-data-customsequence/src/test/java/com/example/custom/sequence/web/controllers/OrderControllerTest.java
+++ b/jpa/boot-data-customsequence/src/test/java/com/example/custom/sequence/web/controllers/OrderControllerTest.java
@@ -43,22 +43,25 @@ import org.springframework.test.web.servlet.MockMvc;
 @ActiveProfiles(PROFILE_TEST)
 class OrderControllerTest {
 
-    @Autowired private MockMvc mockMvc;
+    @Autowired
+    private MockMvc mockMvc;
 
-    @MockitoBean private OrderService orderService;
+    @MockitoBean
+    private OrderService orderService;
 
-    @Autowired private ObjectMapper objectMapper;
+    @Autowired
+    private ObjectMapper objectMapper;
 
     private List<Order> orderList;
     private Customer customer;
 
     @BeforeEach
     void setUp() {
-        customer = new Customer("CUST_01", "customer1", List.of());
+        customer = new Customer().setId("CUST_01").setText("customer1");
         this.orderList = new ArrayList<>();
-        this.orderList.add(new Order("1", "text 1", customer));
-        this.orderList.add(new Order("2", "text 2", customer));
-        this.orderList.add(new Order("3", "text 3", customer));
+        this.orderList.add(new Order().setId("1").setText("text 1").setCustomer(customer));
+        this.orderList.add(new Order().setId("2").setText("text 2").setCustomer(customer));
+        this.orderList.add(new Order().setId("3").setText("text 3").setCustomer(customer));
     }
 
     @Test
@@ -81,15 +84,9 @@ class OrderControllerTest {
 
     private static @NotNull PagedResult<OrderResponse> getOrderResponsePagedResult() {
         List<OrderResponse> orderResponseList = new ArrayList<>();
-        orderResponseList.add(
-                new OrderResponse(
-                        "1", "text 1", new CustomerResponseWithOutOrder("1", "customer1")));
-        orderResponseList.add(
-                new OrderResponse(
-                        "2", "text 2", new CustomerResponseWithOutOrder("1", "customer1")));
-        orderResponseList.add(
-                new OrderResponse(
-                        "3", "text 3", new CustomerResponseWithOutOrder("1", "customer1")));
+        orderResponseList.add(new OrderResponse("1", "text 1", new CustomerResponseWithOutOrder("1", "customer1")));
+        orderResponseList.add(new OrderResponse("2", "text 2", new CustomerResponseWithOutOrder("1", "customer1")));
+        orderResponseList.add(new OrderResponse("3", "text 3", new CustomerResponseWithOutOrder("1", "customer1")));
         Page<OrderResponse> page = new PageImpl<>(orderResponseList);
         return new PagedResult<>(page);
     }
@@ -97,11 +94,8 @@ class OrderControllerTest {
     @Test
     void shouldFindOrderById() throws Exception {
         String orderId = "1";
-        OrderResponse order =
-                new OrderResponse(
-                        orderId,
-                        "text 1",
-                        new CustomerResponseWithOutOrder(customer.getId(), customer.getText()));
+        OrderResponse order = new OrderResponse(
+                orderId, "text 1", new CustomerResponseWithOutOrder(customer.getId(), customer.getText()));
         given(orderService.findOrderById(orderId)).willReturn(Optional.of(order));
 
         this.mockMvc
@@ -122,13 +116,11 @@ class OrderControllerTest {
     void shouldCreateNewOrder() throws Exception {
 
         OrderRequest orderRequest = new OrderRequest("some text", customer.getId());
-        given(orderService.saveOrder(orderRequest))
-                .willReturn(Optional.of(new OrderResponse("1", "some text", null)));
+        given(orderService.saveOrder(orderRequest)).willReturn(Optional.of(new OrderResponse("1", "some text", null)));
         this.mockMvc
-                .perform(
-                        post("/api/orders")
-                                .contentType(MediaType.APPLICATION_JSON)
-                                .content(objectMapper.writeValueAsString(orderRequest)))
+                .perform(post("/api/orders")
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(objectMapper.writeValueAsString(orderRequest)))
                 .andExpect(status().isCreated())
                 .andExpect(jsonPath("$.id", notNullValue()))
                 .andExpect(jsonPath("$.text", is(orderRequest.text())));
@@ -139,10 +131,9 @@ class OrderControllerTest {
         OrderRequest order = new OrderRequest(null, null);
 
         this.mockMvc
-                .perform(
-                        post("/api/orders")
-                                .contentType(MediaType.APPLICATION_JSON)
-                                .content(objectMapper.writeValueAsString(order)))
+                .perform(post("/api/orders")
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(objectMapper.writeValueAsString(order)))
                 .andExpect(status().isBadRequest())
                 .andExpect(header().string("Content-Type", is("application/problem+json")))
                 .andExpect(jsonPath("$.type", is("about:blank")))
@@ -161,20 +152,15 @@ class OrderControllerTest {
     @Test
     void shouldUpdateOrder() throws Exception {
         String orderId = "1";
-        OrderResponse orderResponse =
-                new OrderResponse(
-                        orderId,
-                        "Updated text",
-                        new CustomerResponseWithOutOrder(customer.getId(), customer.getText()));
+        OrderResponse orderResponse = new OrderResponse(
+                orderId, "Updated text", new CustomerResponseWithOutOrder(customer.getId(), customer.getText()));
         OrderRequest orderRequest = new OrderRequest("Updated text", customer.getId());
-        given(orderService.updateOrderById(orderId, orderRequest))
-                .willReturn(Optional.of(orderResponse));
+        given(orderService.updateOrderById(orderId, orderRequest)).willReturn(Optional.of(orderResponse));
 
         this.mockMvc
-                .perform(
-                        put("/api/orders/{id}", orderResponse.id())
-                                .contentType(MediaType.APPLICATION_JSON)
-                                .content(objectMapper.writeValueAsString(orderRequest)))
+                .perform(put("/api/orders/{id}", orderResponse.id())
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(objectMapper.writeValueAsString(orderRequest)))
                 .andExpect(status().isOk())
                 .andExpect(jsonPath("$.text", is(orderResponse.text())));
     }
@@ -186,10 +172,9 @@ class OrderControllerTest {
         given(orderService.updateOrderById(orderId, orderRequest)).willReturn(Optional.empty());
 
         this.mockMvc
-                .perform(
-                        put("/api/orders/{id}", orderId)
-                                .contentType(MediaType.APPLICATION_JSON)
-                                .content(objectMapper.writeValueAsString(orderRequest)))
+                .perform(put("/api/orders/{id}", orderId)
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(objectMapper.writeValueAsString(orderRequest)))
                 .andExpect(status().isNotFound());
 
         verify(orderService, times(1)).updateOrderById(orderId, orderRequest);
@@ -198,11 +183,8 @@ class OrderControllerTest {
     @Test
     void shouldDeleteOrder() throws Exception {
         String orderId = "1";
-        OrderResponse order =
-                new OrderResponse(
-                        orderId,
-                        "Some text",
-                        new CustomerResponseWithOutOrder(customer.getId(), customer.getText()));
+        OrderResponse order = new OrderResponse(
+                orderId, "Some text", new CustomerResponseWithOutOrder(customer.getId(), customer.getText()));
         given(orderService.findOrderById(orderId)).willReturn(Optional.of(order));
         doNothing().when(orderService).deleteOrderById(order.id());
 

--- a/scheduler/boot-scheduler-shedlock/pom.xml
+++ b/scheduler/boot-scheduler-shedlock/pom.xml
@@ -220,7 +220,7 @@
                 <configuration>
                     <java>
                         <palantirJavaFormat>
-                            <version>2.47.0</version>
+                            <version>2.67.0</version>
                         </palantirJavaFormat>
                         <importOrder />
                         <removeUnusedImports />

--- a/scheduler/boot-scheduler-shedlock/src/main/java/com/learning/shedlock/entities/Job.java
+++ b/scheduler/boot-scheduler-shedlock/src/main/java/com/learning/shedlock/entities/Job.java
@@ -22,25 +22,22 @@ public class Job {
 
     public Job() {}
 
-    public Job(Long id, String text) {
-        this.id = id;
-        this.text = text;
-    }
-
     public Long getId() {
         return id;
     }
 
-    public void setId(Long id) {
+    public Job setId(Long id) {
         this.id = id;
+        return this;
     }
 
     public String getText() {
         return text;
     }
 
-    public void setText(String text) {
+    public Job setText(String text) {
         this.text = text;
+        return this;
     }
 
     @Override

--- a/scheduler/boot-scheduler-shedlock/src/main/java/com/learning/shedlock/mapper/JobMapper.java
+++ b/scheduler/boot-scheduler-shedlock/src/main/java/com/learning/shedlock/mapper/JobMapper.java
@@ -10,9 +10,7 @@ import org.springframework.stereotype.Service;
 public class JobMapper {
 
     public Job toEntity(JobRequest jobRequest) {
-        Job job = new Job();
-        job.setText(jobRequest.text());
-        return job;
+        return new Job().setText(jobRequest.text());
     }
 
     public void mapJobWithRequest(Job job, JobRequest jobRequest) {

--- a/scheduler/boot-scheduler-shedlock/src/test/java/com/learning/shedlock/services/JobServiceTest.java
+++ b/scheduler/boot-scheduler-shedlock/src/test/java/com/learning/shedlock/services/JobServiceTest.java
@@ -55,10 +55,7 @@ class JobServiceTest {
     }
 
     private Job getJob() {
-        Job job = new Job();
-        job.setId(1L);
-        job.setText("junitTest");
-        return job;
+        return new Job().setId(1L).setText("junitTest");
     }
 
     private JobResponse getJobResponse() {

--- a/scheduler/boot-scheduler-shedlock/src/test/java/com/learning/shedlock/web/controllers/JobControllerIT.java
+++ b/scheduler/boot-scheduler-shedlock/src/test/java/com/learning/shedlock/web/controllers/JobControllerIT.java
@@ -35,9 +35,9 @@ class JobControllerIT extends AbstractIntegrationTest {
         jobRepository.deleteAllInBatch();
 
         jobList = new ArrayList<>();
-        jobList.add(new Job(null, "First Job"));
-        jobList.add(new Job(null, "Second Job"));
-        jobList.add(new Job(null, "Third Job"));
+        jobList.add(new Job().setText("First Job"));
+        jobList.add(new Job().setText("Second Job"));
+        jobList.add(new Job().setText("Third Job"));
         jobList = jobRepository.saveAll(jobList);
     }
 

--- a/scheduler/boot-scheduler-shedlock/src/test/java/com/learning/shedlock/web/controllers/JobControllerTest.java
+++ b/scheduler/boot-scheduler-shedlock/src/test/java/com/learning/shedlock/web/controllers/JobControllerTest.java
@@ -57,9 +57,9 @@ class JobControllerTest {
     @BeforeEach
     void setUp() {
         this.jobList = new ArrayList<>();
-        this.jobList.add(new Job(1L, "text 1"));
-        this.jobList.add(new Job(2L, "text 2"));
-        this.jobList.add(new Job(3L, "text 3"));
+        this.jobList.add(new Job().setId(1L).setText("text 1"));
+        this.jobList.add(new Job().setId(2L).setText("text 2"));
+        this.jobList.add(new Job().setId(3L).setText("text 3"));
     }
 
     @Test


### PR DESCRIPTION
Switch formatter to palantirJavaFormat

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Style**
  * Improved code formatting and consistency across source and test files, including annotation placement, method chaining, and lambda expressions. No changes to application logic or behavior.

* **Chores**
  * Updated code formatting rules and tools, switching to a new Java formatter and enforcing import order and annotation formatting.
  * Updated MariaDB test container version from 11.7 to 11.8.

* **Refactor**
  * Replaced constructor-based entity creation with setter-based initialization in some test and mapping code for improved clarity.
  * Modified setter methods in entities to support method chaining.

* **Bug Fixes**
  * Removed unused constructors from entity classes to streamline code.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->