### PR TITLE
chore: replace Bitnami image references with Soldevelo equivalents

### DIFF
--- a/jpa/boot-read-replica-postgresql/docker-compose.yaml
+++ b/jpa/boot-read-replica-postgresql/docker-compose.yaml
@@ -1,6 +1,6 @@
 services:
   postgresql-master:
-    image: 'bitnami/postgresql:latest'
+    image: 'soldevelo/postgresql:latest'
     ports:
       - '5432:5432'
     volumes:
@@ -15,7 +15,7 @@ services:
       - POSTGRESQL_PASSWORD=postgres_write
       - POSTGRESQL_DATABASE=my_database
   postgresql-slave:
-    image: 'bitnami/postgresql:latest'
+    image: 'soldevelo/postgresql:latest'
     ports:
       - '15432:5432'
     depends_on:


### PR DESCRIPTION
## Why this change

Bitnami changed its container image distribution model on August 28, 2025, and public images no longer receive ongoing updates or security fixes.
[SolDevelo](https://hub.docker.com/u/soldevelo) images are free drop-in replacements built from [SolDevelo/containers](https://github.com/SolDevelo/containers), a fork of bitnami/containers that continues to provide actively maintained and publicly available images.

## Image replacements

- `bitnami/postgresql:latest` → [`soldevelo/postgresql:latest`](https://hub.docker.com/r/soldevelo/postgresql)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated the PostgreSQL service image used by both database instances in the development environment.
  * No changes were made to ports, volumes, environment settings, or service dependencies.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->